### PR TITLE
Graylog now expect a non-empty hostname.

### DIFF
--- a/src/flowgger/encoder/gelf_encoder.rs
+++ b/src/flowgger/encoder/gelf_encoder.rs
@@ -36,7 +36,7 @@ impl Encoder for GelfEncoder {
     fn encode(&self, record: Record) -> Result<Vec<u8>, &'static str> {
         let mut map = ObjectBuilder::new()
             .insert("version".to_owned(), Value::String("1.1".to_owned()))
-            .insert("host".to_owned(), Value::String(record.hostname))
+            .insert("host".to_owned(), Value::String(record.hostname.unwrap_or_else(|| "unknown".to_owned())))
             .insert(
                 "short_message".to_owned(),
                 Value::String(record.msg.unwrap_or_else(|| "-".to_owned())),


### PR DESCRIPTION
Hello, 

Graylog now check that host is not blank.

https://github.com/Graylog2/graylog2-server/blob/238f08d7ae0ef54ed9962d58357607b3a597c056/graylog2-server/src/main/java/org/graylog2/inputs/codecs/GelfCodec.java#L240

This patch on flowgger will help to avoid loosing logs if hostname is never given.

Thanks for the merge, build & new release, you are the best.

Signed-off-by: Pierre De Paepe <pierre.de-paepe@corp.ovh.com>