### PR TITLE
Lower docker image size and switch to OpenSSL in docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+target
+docker/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,62 +1,42 @@
-FROM jedisct1/base-dev-rust-nightly:94e884b63
-MAINTAINER Frank Denis
-ENV SERIAL 1
+FROM rust:1.38 AS builder
+MAINTAINER Frank Denis, Damian Czaja
 
-ENV DEBIAN_FRONTEND noninteractive
-
-ENV BUILD_DEPS \
-    autoconf \
-    automake \
-    libtool \
-    file \
-    gcc \
-    g++ \
-    git \
-    libc-dev \
-    make \
-    pkg-config
-
-RUN set -x && \
-    apt-get install -y \
-        $BUILD_DEPS \
-        libsnappy-dev \
-        --no-install-recommends && \
-    apt-get clean && \
-    rm -fr /tmp/* /var/tmp/*
-
-ENV LIBRESSL_VERSION 2.7.0
-ENV LIBRESSL_SHA256 50ce6d6f88dea73a3efca62b0a9e6ca75292bdee6c9293efd6a771cfdb28cdee
+ENV LIBRESSL_VERSION 2.9.2
+ENV LIBRESSL_SHA256 c4c78167fae325b47aebd8beb54b6041d6f6a56b3743f4bd5d79b15642f9d5d4
 ENV LIBRESSL_DOWNLOAD_URL https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${LIBRESSL_VERSION}.tar.gz
-
-RUN set -x && \
-    mkdir -p /tmp/src && \
-    cd /tmp/src && \
-    curl -sSL $LIBRESSL_DOWNLOAD_URL -o libressl.tar.gz && \
-    echo "${LIBRESSL_SHA256} *libressl.tar.gz" | sha256sum -c - && \
-    tar xzf libressl.tar.gz && \
-    rm -f libressl.tar.gz && \
-    cd libressl-${LIBRESSL_VERSION} && \
-    ./configure --disable-shared --with-pic --disable-dependency-tracking --prefix=/opt/libressl && \
-    make check && make install && \
-    rm -fr /opt/libressl/share/man && \
-    echo /opt/libressl/lib > /etc/ld.so.conf.d/libressl.conf && ldconfig && \
-    rm -fr /tmp/*
 
 ENV OPENSSL_LIB_DIR=/opt/libressl/lib
 ENV OPENSSL_INCLUDE_DIR=/opt/libressl/include
 
-RUN set -x && \
-    cd /tmp && \
-    git clone https://github.com/jedisct1/flowgger.git && \
-    cd flowgger && \
-    cargo build --release --features='coroutines ecdh kafka' && \
-    mkdir -p /opt/flowgger/etc /opt/flowgger/bin && \
-    strip target/release/flowgger && \
-    mv target/release/flowgger /opt/flowgger/bin/ && \
-    rm -fr /tmp/flowgger
+RUN apt-get update && \
+	apt-get install -y \
+		capnproto && \
+	curl -sSL $LIBRESSL_DOWNLOAD_URL -o libressl.tar.gz && \
+    echo "${LIBRESSL_SHA256} *libressl.tar.gz" | sha256sum -c - && \
+    tar xzf libressl.tar.gz && \
+    cd libressl-${LIBRESSL_VERSION} && \
+    ./configure --disable-shared --with-pic --disable-dependency-tracking --prefix=/opt/libressl && \
+    make check && make install
 
-COPY flowgger.sh /etc/service/flowgger/run
+COPY . /flowgger
 
-EXPOSE 6514
+RUN cd /flowgger && \
+    cargo build --release && \
+    strip target/release/flowgger
 
-ENTRYPOINT ["/sbin/my_init"]
+
+FROM debian:buster-slim
+
+ENV OPENSSL_LIB_DIR=/opt/libressl/lib
+ENV OPENSSL_INCLUDE_DIR=/opt/libressl/include
+
+WORKDIR /opt/flowgger
+
+RUN mkdir -p /opt/flowgger/bin /opt/flowgger/etc
+COPY --from=builder /flowgger/target/release/flowgger /opt/flowgger/bin/flowgger
+COPY --from=builder /opt/libressl /opt/libressl
+COPY docker/entrypoint.sh /
+COPY flowgger.toml /opt/flowgger/etc/flowgger.toml
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/opt/flowgger/etc/flowgger.toml"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,42 +1,26 @@
 FROM rust:1.38 AS builder
-LABEL maintainer="Frank Denis, Damian Czaja <trojan295@gmail.com>"
 
-ENV LIBRESSL_VERSION 2.9.2
-ENV LIBRESSL_SHA256 c4c78167fae325b47aebd8beb54b6041d6f6a56b3743f4bd5d79b15642f9d5d4
-ENV LIBRESSL_DOWNLOAD_URL https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${LIBRESSL_VERSION}.tar.gz
-
-ENV OPENSSL_LIB_DIR=/opt/libressl/lib
-ENV OPENSSL_INCLUDE_DIR=/opt/libressl/include
+WORKDIR /flowgger
+COPY . .
 
 RUN apt-get update && \
-	apt-get install -y \
-		capnproto && \
-	curl -sSL $LIBRESSL_DOWNLOAD_URL -o libressl.tar.gz && \
-    echo "${LIBRESSL_SHA256} *libressl.tar.gz" | sha256sum -c - && \
-    tar xzf libressl.tar.gz && \
-    cd libressl-${LIBRESSL_VERSION} && \
-    ./configure --disable-shared --with-pic --disable-dependency-tracking --prefix=/opt/libressl && \
-    make check && make install
-
-COPY . /flowgger
-
-RUN cd /flowgger && \
+	apt-get install -y capnproto && \
     cargo build --release && \
     strip target/release/flowgger
 
 
 FROM debian:buster-slim
-
-ENV OPENSSL_LIB_DIR=/opt/libressl/lib
-ENV OPENSSL_INCLUDE_DIR=/opt/libressl/include
+LABEL maintainer="Frank Denis, Damian Czaja <trojan295@gmail.com>"
 
 WORKDIR /opt/flowgger
 
-RUN mkdir -p /opt/flowgger/bin /opt/flowgger/etc
+RUN apt-get update && \
+	apt-get install -y libssl1.1 && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /flowgger/target/release/flowgger /opt/flowgger/bin/flowgger
-COPY --from=builder /opt/libressl /opt/libressl
-COPY docker/entrypoint.sh /
 COPY flowgger.toml /opt/flowgger/etc/flowgger.toml
+COPY docker/entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/opt/flowgger/etc/flowgger.toml"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.38 AS builder
-MAINTAINER Frank Denis, Damian Czaja
+LABEL maintainer="Frank Denis, Damian Czaja <trojan295@gmail.com>"
 
 ENV LIBRESSL_VERSION 2.9.2
 ENV LIBRESSL_SHA256 c4c78167fae325b47aebd8beb54b6041d6f6a56b3743f4bd5d79b15642f9d5d4

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /opt/flowgger/bin/flowgger $@

--- a/docker/flowgger.sh
+++ b/docker/flowgger.sh
@@ -1,3 +1,0 @@
-#! /bin/sh
-
-exec /opt/flowgger/bin/flowgger /opt/flowgger/etc/flowgger.toml


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:*
This PR updates the Dockerfile, by changing LibreSSL to OpenSSL there and lowering the output image size do 76MB, by using a multi-stage Docker build and `debian:buster-slim` as a base image

--

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
