### PR TITLE
Replace coio with may

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [features]
 capnp-recompile = ["capnpc", "capnp"]
-coroutines = ["tokio", "tls", "futures"]
+coroutines = ["may", "tls", "futures"]
 default = ["syslog", "kafka-output", "file", "redis", "capnp-recompile", "tls", "gelf", "ltsv"]
 redis-input = ["redis"]
 kafka-output = ["kafka"]
@@ -45,7 +45,7 @@ rand = "0.5"
 redis = { version = "0.10", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "~0.8", optional = true }
-tokio = { version = "0.1", optional = true }
+may = { version = "~0.3", optional = true }
 toml = "0.5"
 time = "0.1"
 futures = { version = "0.1", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [features]
 capnp-recompile = ["capnpc", "capnp"]
-coroutines = ["coio", "tls"]
+coroutines = ["tokio", "tls", "futures"]
 default = ["syslog", "kafka-output", "file", "redis", "capnp-recompile", "tls", "gelf", "ltsv"]
 redis-input = ["redis"]
 kafka-output = ["kafka"]
@@ -35,7 +35,6 @@ optional = true
 capnp = { version = "0.9", optional = true }
 chrono = "0.4"
 clap = "2"
-coio = { git = "https://github.com/zonyitoo/coio-rs", optional = true }
 flate2 = "1"
 glob = { version = "0.3", optional = true }
 kafka = { version = "0.8", features = ["snappy", "gzip", "security"], optional = true }
@@ -46,9 +45,10 @@ rand = "0.5"
 redis = { version = "0.10", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "~0.8", optional = true }
+tokio = { version = "0.1", optional = true }
 toml = "0.5"
 time = "0.1"
-
+futures = { version = "0.1", optional = true}
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/lib.rs"
 
 [features]
 capnp-recompile = ["capnpc", "capnp"]
-coroutines = ["may", "tls", "futures"]
+coroutines = ["may", "tls"]
 default = ["syslog", "kafka-output", "file", "redis", "capnp-recompile", "tls", "gelf", "ltsv"]
 redis-input = ["redis"]
 kafka-output = ["kafka"]
@@ -48,7 +48,6 @@ serde_json = { version = "~0.8", optional = true }
 may = { version = "~0.3", optional = true }
 toml = "0.5"
 time = "0.1"
-futures = { version = "0.1", optional = true}
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/flowgger.toml
+++ b/flowgger.toml
@@ -12,18 +12,18 @@
 # src = "/var/lib/docker/containers/*/*.log"
 
 ### Syslog over UDP
-#type = "udp"
-#listen = "0.0.0.0:514"
+type = "udp"
+listen = "0.0.0.0:514"
 
 ### TCP
 # type = "tcp"
 # listen = "0.0.0.0:6514"
 # timeout = 3600
 
-# TCP, using coroutines
-type = "tcp_co"
-listen = "0.0.0.0:6514"
-tcp_threads = 1
+### TCP, using coroutines
+# type = "tcp_co"
+# listen = "0.0.0.0:6514"
+# tcp_threads = 1
 
 ### TLS
 # type = "tls"

--- a/flowgger.toml
+++ b/flowgger.toml
@@ -12,18 +12,18 @@
 # src = "/var/lib/docker/containers/*/*.log"
 
 ### Syslog over UDP
-type = "udp"
-listen = "0.0.0.0:514"
+#type = "udp"
+#listen = "0.0.0.0:514"
 
 ### TCP
 # type = "tcp"
 # listen = "0.0.0.0:6514"
 # timeout = 3600
 
-### TCP, using coroutines
-# type = "tcp_co"
-# listen = "0.0.0.0:6514"
-# tcp_threads = 1
+# TCP, using coroutines
+type = "tcp_co"
+listen = "0.0.0.0:6514"
+tcp_threads = 1
 
 ### TLS
 # type = "tls"

--- a/src/flowgger/input/tls/tlsco_input.rs
+++ b/src/flowgger/input/tls/tlsco_input.rs
@@ -5,11 +5,13 @@ use crate::flowgger::encoder::Encoder;
 use crate::flowgger::splitter::{
     CapnpSplitter, LineSplitter, NulSplitter, Splitter, SyslenSplitter,
 };
-use coio::net::{TcpListener, TcpStream};
-use coio::Scheduler;
+use futures::future;
+use futures::stream::Stream;
 use std::io::{stderr, BufReader, Write};
 use std::net::SocketAddr;
 use std::sync::mpsc::SyncSender;
+use tokio;
+use tokio::net::{TcpListener, TcpStream};
 
 pub struct TlsCoInput {
     listen: String,
@@ -32,26 +34,26 @@ impl Input for TlsCoInput {
     ) {
         let tls_config = self.tls_config.clone();
         let threads = tls_config.threads;
+
         let listen: SocketAddr = self.listen.parse().unwrap();
-        Scheduler::new()
-            .with_workers(threads)
-            .run(move || {
-                let listener = TcpListener::bind(listen).unwrap();
-                for client in listener.incoming() {
-                    match client {
-                        Ok((client, _addr)) => {
-                            let tx = tx.clone();
-                            let (decoder, encoder) = (decoder.clone_boxed(), encoder.clone_boxed());
-                            let tls_config = tls_config.clone();
-                            Scheduler::spawn(move || {
-                                handle_client(client, tx, decoder, encoder, tls_config);
-                            });
-                        }
-                        Err(_) => {}
-                    }
-                }
-            })
-            .unwrap();
+
+        let listener = TcpListener::bind(&listen).unwrap();
+
+        tokio::run(future::lazy(move || {
+            listener
+                .incoming()
+                .map_err(|e| println!("error when accepting incoming TCP connection: {:?}", e))
+                .for_each(|socket| {
+                    let tx = tx.clone();
+                    let (decoder, encoder) = (decoder.clone_boxed(), encoder.clone_boxed());
+                    let tls_config = tls_config.clone();
+                    tokio::spawn(future::lazy(|| {
+                        handle_client(socket, tx, decoder, encoder, tls_config);
+                        Ok(())
+                    }))
+                });
+            Ok(())
+        }));
     }
 }
 

--- a/src/flowgger/mod.rs
+++ b/src/flowgger/mod.rs
@@ -13,8 +13,6 @@ extern crate capnp;
 extern crate chrono;
 extern crate clap;
 extern crate flate2;
-#[cfg(feature = "coroutines")]
-extern crate futures;
 #[cfg(feature = "file")]
 extern crate glob;
 #[cfg(feature = "kafka-output")]
@@ -28,10 +26,7 @@ extern crate rand;
 extern crate redis;
 #[cfg(feature = "gelf")]
 extern crate serde_json;
-#[cfg(feature = "coroutines")]
-extern crate tokio;
 extern crate toml;
-
 #[cfg(feature = "capnp-recompile")]
 pub mod record_capnp;
 

--- a/src/flowgger/mod.rs
+++ b/src/flowgger/mod.rs
@@ -12,9 +12,9 @@ mod utils;
 extern crate capnp;
 extern crate chrono;
 extern crate clap;
-#[cfg(feature = "coroutines")]
-extern crate coio;
 extern crate flate2;
+#[cfg(feature = "coroutines")]
+extern crate futures;
 #[cfg(feature = "file")]
 extern crate glob;
 #[cfg(feature = "kafka-output")]
@@ -28,7 +28,10 @@ extern crate rand;
 extern crate redis;
 #[cfg(feature = "gelf")]
 extern crate serde_json;
+#[cfg(feature = "coroutines")]
+extern crate tokio;
 extern crate toml;
+
 #[cfg(feature = "capnp-recompile")]
 pub mod record_capnp;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "coroutines")]
+#[macro_use]
+extern crate may;
+
 pub mod flowgger;
 
 /// Start a flowgger instance starting from a file path


### PR DESCRIPTION
*Issue #, if available:* #45 

*Description of changes:*
This PR replaces the coio library with [may](https://github.com/Xudong-Huang/may).

I put the `extern crate` in `lib.rs`, because crates with macros need to be imported in the crate root. `go!` macro is used to spawn a new coroutines, but it could be replaced with the `spawn` functions, if you want to keep the crates in `mod.rs`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
