### PR TITLE
Github Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,21 @@ matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-musl
-    - env: TARGET=i686-unknown-linux-gnu DISABLE_TESTS=1
+    # - env: TARGET=i686-unknown-linux-gnu DISABLE_TESTS=1
     # - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
     # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
-    - env: TARGET=aarch64-unknown-linux-gnu DISABLE_TESTS=1
-    - env: TARGET=armv7-unknown-linux-gnueabihf DISABLE_TESTS=1
-    - env: TARGET=mips-unknown-linux-gnu DISABLE_TESTS=1
-    - env: TARGET=mips64-unknown-linux-gnuabi64 DISABLE_TESTS=1
-    - env: TARGET=mips64el-unknown-linux-gnuabi64 DISABLE_TESTS=1
-    - env: TARGET=mipsel-unknown-linux-gnu DISABLE_TESTS=1
-    - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
-    - env: TARGET=powerpc64-unknown-linux-gnu DISABLE_TESTS=1
-    - env: TARGET=powerpc64le-unknown-linux-gnu DISABLE_TESTS=1
-    - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
-  allow_failures:
-    - env: TARGET=aarch64-unknown-linux-musl DISABLE_TESTS=1
+    # - env: TARGET=aarch64-unknown-linux-gnu DISABLE_TESTS=1
+    # - env: TARGET=armv7-unknown-linux-gnueabihf DISABLE_TESTS=1
+    # - env: TARGET=mips-unknown-linux-gnu DISABLE_TESTS=1
+    # - env: TARGET=mips64-unknown-linux-gnuabi64 DISABLE_TESTS=1
+    # - env: TARGET=mips64el-unknown-linux-gnuabi64 DISABLE_TESTS=1
+    # - env: TARGET=mipsel-unknown-linux-gnu DISABLE_TESTS=1
+    # - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
+    # - env: TARGET=powerpc64-unknown-linux-gnu DISABLE_TESTS=1
+    # - env: TARGET=powerpc64le-unknown-linux-gnu DISABLE_TESTS=1
+    # - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
+    #allow_failures:
+    #  - env: TARGET=aarch64-unknown-linux-musl DISABLE_TESTS=1
 
 before_install: set -e
 
@@ -46,6 +46,14 @@ after_script: set +e
 
 before_deploy:
   - sh ci/before_deploy.sh
+
+deploy:
+  provider: releases
+  api_key: "${GITHUB_APIKEY}"
+  file: "target/${TARGET}/release/flowgger"
+  skip_cleanup: true
+  on:
+    tags: true
 
 cache: cargo
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - CRATE_NAME=flowgger
     - TARGET=x86_64-unknown-linux-gnu
-    - FEATURES="syslog kafka-output file redis tls gelf ltsv"
+    - FLOWGGER_FEATURES="syslog kafka-output file redis tls gelf ltsv"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,21 +17,21 @@ matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-musl
-    # - env: TARGET=i686-unknown-linux-gnu DISABLE_TESTS=1
-    # - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
-    # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
-    # - env: TARGET=aarch64-unknown-linux-gnu DISABLE_TESTS=1
-    # - env: TARGET=armv7-unknown-linux-gnueabihf DISABLE_TESTS=1
-    # - env: TARGET=mips-unknown-linux-gnu DISABLE_TESTS=1
-    # - env: TARGET=mips64-unknown-linux-gnuabi64 DISABLE_TESTS=1
-    # - env: TARGET=mips64el-unknown-linux-gnuabi64 DISABLE_TESTS=1
-    # - env: TARGET=mipsel-unknown-linux-gnu DISABLE_TESTS=1
-    # - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
-    # - env: TARGET=powerpc64-unknown-linux-gnu DISABLE_TESTS=1
-    # - env: TARGET=powerpc64le-unknown-linux-gnu DISABLE_TESTS=1
-    # - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
-    #allow_failures:
-    #  - env: TARGET=aarch64-unknown-linux-musl DISABLE_TESTS=1
+    - env: TARGET=i686-unknown-linux-gnu DISABLE_TESTS=1
+    - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
+    - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
+    - env: TARGET=aarch64-unknown-linux-gnu DISABLE_TESTS=1
+    - env: TARGET=armv7-unknown-linux-gnueabihf DISABLE_TESTS=1
+    - env: TARGET=mips-unknown-linux-gnu DISABLE_TESTS=1
+    - env: TARGET=mips64-unknown-linux-gnuabi64 DISABLE_TESTS=1
+    - env: TARGET=mips64el-unknown-linux-gnuabi64 DISABLE_TESTS=1
+    - env: TARGET=mipsel-unknown-linux-gnu DISABLE_TESTS=1
+    - env: TARGET=powerpc-unknown-linux-gnu DISABLE_TESTS=1
+    - env: TARGET=powerpc64-unknown-linux-gnu DISABLE_TESTS=1
+    - env: TARGET=powerpc64le-unknown-linux-gnu DISABLE_TESTS=1
+    - env: TARGET=s390x-unknown-linux-gnu DISABLE_TESTS=1
+  allow_failures:
+    - env: TARGET=aarch64-unknown-linux-musl DISABLE_TESTS=1
 
 install:
   - sh ci/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,11 @@ after_script: set +e
 
 before_deploy:
   - sh ci/before_deploy.sh
-
+  - mv "target/${TARGET}/release/flowgger" "flowgger_${TARGET}"
 deploy:
   provider: releases
   api_key: "${GITHUB_APIKEY}"
-  file: "target/${TARGET}/release/flowgger"
+  file: "flowgger_${TARGET}"
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Based on the "trust" template v0.1.1
 # https://github.com/japaric/trust/tree/v0.1.1
 
-dist: trusty
+dist: bionic
 language: rust
 services: docker
 sudo: required
@@ -12,14 +12,15 @@ env:
   global:
     - CRATE_NAME=flowgger
     - TARGET=x86_64-unknown-linux-gnu
+    - FEATURES="syslog kafka-output file redis tls gelf ltsv"
 
 matrix:
   include:
     - env: TARGET=x86_64-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-musl
     - env: TARGET=i686-unknown-linux-gnu DISABLE_TESTS=1
-    - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
-    - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
+    # - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
+    # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
     - env: TARGET=aarch64-unknown-linux-gnu DISABLE_TESTS=1
     - env: TARGET=armv7-unknown-linux-gnueabihf DISABLE_TESTS=1
     - env: TARGET=mips-unknown-linux-gnu DISABLE_TESTS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_deploy:
 deploy:
   provider: releases
   api_key: "${GITHUB_APIKEY}"
-  file: "release/flowgger*"
+  file: "flowgger_${TARGET}.zip"
   skip_cleanup: true
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ matrix:
     #allow_failures:
     #  - env: TARGET=aarch64-unknown-linux-musl DISABLE_TESTS=1
 
-before_install: set -e
-
 install:
   - sh ci/install.sh
   - source ~/.cargo/env || true
@@ -42,15 +40,13 @@ install:
 script:
   - bash ci/script.sh
 
-after_script: set +e
-
 before_deploy:
   - sh ci/before_deploy.sh
-  - mv "target/${TARGET}/release/flowgger" "flowgger_${TARGET}"
+
 deploy:
   provider: releases
   api_key: "${GITHUB_APIKEY}"
-  file: "flowgger_${TARGET}"
+  file: "release/flowgger*"
   skip_cleanup: true
   on:
     tags: true

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -8,7 +8,7 @@ main() {
 
     test -f Cargo.lock || cargo generate-lockfile
 
-    cross rustc --bin flowgger --target $TARGET --release --no-default-features -- -C lto
+    cross rustc --bin flowgger --target $TARGET --release --no-default-features --features "syslog kafka-output file redis tls gelf ltsv" -- -C lto
     cp target/$TARGET/release/flowgger $release_dir/flowgger
     cp flowgger.toml $release_dir/
     zip -jr flowgger_$TARGET.zip $release_dir

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -8,7 +8,7 @@ main() {
 
     test -f Cargo.lock || cargo generate-lockfile
 
-    cross rustc --bin flowgger --target $TARGET --release --no-default-features --features "syslog kafka-output file redis tls gelf ltsv" -- -C lto
+    cross rustc --bin flowgger --target $TARGET --release --no-default-features --features "${FLOWGGER_FEATURES}" -- -C lto
     cp target/$TARGET/release/flowgger $release_dir/flowgger
     cp flowgger.toml $release_dir/
     zip -jr flowgger_$TARGET.zip $release_dir

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -3,31 +3,14 @@
 set -ex
 
 main() {
-    local src=$(pwd) \
-          stage=
-
-    case $TRAVIS_OS_NAME in
-        linux)
-            stage=$(mktemp -d)
-            ;;
-        osx)
-            stage=$(mktemp -d -t tmp)
-            ;;
-    esac
+    local release_dir="$(pwd)/release"
+    mkdir -p $release_dir
 
     test -f Cargo.lock || cargo generate-lockfile
 
-    # TODO Update this to build the artifacts that matter to you
     cross rustc --bin flowgger --target $TARGET --release --no-default-features -- -C lto
 
-    # TODO Update this to package the right artifacts
-    cp target/$TARGET/release/flowgger $stage/
-
-    cd $stage
-    tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *
-    cd $src
-
-    rm -rf $stage
+    cp target/$TARGET/release/flowgger $release_dir/flowgger_$TARGET
 }
 
 main

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -9,8 +9,9 @@ main() {
     test -f Cargo.lock || cargo generate-lockfile
 
     cross rustc --bin flowgger --target $TARGET --release --no-default-features -- -C lto
-
-    cp target/$TARGET/release/flowgger $release_dir/flowgger_$TARGET
+    cp target/$TARGET/release/flowgger $release_dir/flowgger
+    cp flowgger.toml $release_dir/
+    zip -jr flowgger_$TARGET.zip $release_dir
 }
 
 main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,7 +4,7 @@ set -ex
 
 main() {
     if [ -z $DISABLE_TESTS ]; then
-        cross test --target $TARGET --no-default-features
+        cross test --target $TARGET --no-default-features --features "syslog kafka-output file redis tls gelf ltsv"
     fi
 }
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -6,8 +6,6 @@ main() {
     if [ -z $DISABLE_TESTS ]; then
         cross test --target $TARGET --no-default-features
     fi
-
-    cross build --target $TARGET --release --no-default-features
 }
 
 main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,18 +2,12 @@
 
 set -ex
 
-# TODO This is the "test phase", tweak it as you see fit
 main() {
-    cross build --target $TARGET --no-default-features
-
-    if [ ! -z $DISABLE_TESTS ]; then
-        return
+    if [ -z $DISABLE_TESTS ]; then
+        cross test --target $TARGET --no-default-features
     fi
 
-    cross test --target $TARGET --no-default-features
+    cross build --target $TARGET --release --no-default-features
 }
 
-# we don't run the "test phase" when doing deploys
-if [ -z $TRAVIS_TAG ]; then
-    main
-fi
+main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,7 +4,7 @@ set -ex
 
 main() {
     if [ -z $DISABLE_TESTS ]; then
-        cross test --target $TARGET --no-default-features --features "syslog kafka-output file redis tls gelf ltsv"
+        cross test --target $TARGET --no-default-features --features "${FLOWGGER_FEATURES}"
     fi
 }
 

--- a/src/flowgger/output/file_output.rs
+++ b/src/flowgger/output/file_output.rs
@@ -77,8 +77,7 @@ impl FileOutput {
             |rot_time| {
                 rot_time
                     .as_integer()
-                    .expect("output.file_rotation_time should be an integer")
-                    as u32
+                    .expect("output.file_rotation_time should be an integer") as u32
             },
         );
         // Get the optional file rotation max files. Default is 2
@@ -91,14 +90,14 @@ impl FileOutput {
                     as i32
             },
         );
-        let time_format = config
-            .lookup("output.file_rotation_timeformat")
-            .map_or(FILE_DEFAULT_TIME_FORMAT.to_string(), |bs| {
+        let time_format = config.lookup("output.file_rotation_timeformat").map_or(
+            FILE_DEFAULT_TIME_FORMAT.to_string(),
+            |bs| {
                 bs.as_str()
                     .expect("output.file_rotation_timeformat should be a string")
                     .to_string()
-            });
-
+            },
+        );
 
         FileOutput {
             path,
@@ -129,11 +128,13 @@ impl FileOutput {
         let file_writer: Option<Box<dyn Write + Send>>;
 
         // Rotation option is enabled, open a rotating file writer
-        let mut rotating_file = RotatingFile::new(&self.path,
-                                                  self.rotation_size,
-                                                  self.rotation_time,
-                                                  self.rotation_maxfiles,
-                                                  &self.time_format);
+        let mut rotating_file = RotatingFile::new(
+            &self.path,
+            self.rotation_size,
+            self.rotation_time,
+            self.rotation_maxfiles,
+            &self.time_format,
+        );
         if rotating_file.is_enabled() {
             file_writer = match rotating_file.open() {
                 Ok(_) => Some(Box::new(rotating_file)),
@@ -220,24 +221,28 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::{thread, time};
     extern crate tempdir;
-    use tempdir::TempDir;
     use std::io::Result;
+    use tempdir::TempDir;
 
     /// Helper for the test to initialize some test data, create a writer,  and verify it
     struct WriterTest {
         file_base: String,
         test_patterns: Vec<&'static str>,
-        _temp_dir:TempDir,
+        _temp_dir: TempDir,
     }
 
     impl WriterTest {
         fn new(file_name: &'static str) -> Result<Self> {
             let temp_dir = TempDir::new("test_file_output")?;
-            let file_base = temp_dir.path().join(file_name).to_string_lossy().to_string();
+            let file_base = temp_dir
+                .path()
+                .join(file_name)
+                .to_string_lossy()
+                .to_string();
             Ok(Self {
                 file_base,
                 test_patterns: vec!["abcdef", "ghijkl", "012345", "678901"],
-                _temp_dir:temp_dir,
+                _temp_dir: temp_dir,
             })
         }
 
@@ -295,7 +300,10 @@ mod tests {
     #[test]
     #[should_panic(expected = "output.file_rotation_timeformat should be a string")]
     fn test_invalid_time_format() {
-        let cfg = Config::from_string(&format!("[output]\nfile_path = \"output_file\"\nfile_rotation_timeformat = 123\n")).unwrap();
+        let cfg = Config::from_string(&format!(
+            "[output]\nfile_path = \"output_file\"\nfile_rotation_timeformat = 123\n"
+        ))
+        .unwrap();
         let _ = FileOutput::new(&cfg);
     }
 
@@ -335,13 +343,13 @@ mod tests {
         let cfg = Config::from_string(&format!(
             "[output]\nfile_path = \"output_file\"\nfile_rotation_time= \"15s\"\n"
         ))
-            .unwrap();
+        .unwrap();
         let _ = FileOutput::new(&cfg);
     }
 
     #[test]
     fn test_start_no_merger() -> Result<()> {
-        let file_base = "test_start_no_merger";
+        let file_base = "/tmp/test_start_no_merger";
         let test_object = WriterTest::new(file_base)?;
         let cfg =
             Config::from_string(&format!("[output]\nfile_path = \"{}\"\n", file_base)).unwrap();
@@ -360,7 +368,7 @@ mod tests {
 
     #[test]
     fn test_start_with_merger() -> Result<()> {
-        let file_base = "test_start_with_merger";
+        let file_base = "/tmp/test_start_with_merger";
         let test_object = WriterTest::new(file_base)?;
         let cfg =
             Config::from_string(&format!("[output]\nfile_path = \"{}\"\n", file_base)).unwrap();
@@ -433,7 +441,7 @@ mod tests {
             "[output]\nfile_path = \"{}\"\nfile_rotation_size = 15\nfile_rotation_time = 2\n",
             test_object.get_file_base()
         ))
-            .unwrap();
+        .unwrap();
         let _writer = test_object.setup_writer(
             cfg,
             15,


### PR DESCRIPTION
*Issue #, if available:* none, somehow connected with https://github.com/awslabs/flowgger/issues/32

*Description of changes:*
This PR adds a feature to publish flowgger release packages as GitHub Releases. It publishes a zip with the flowgger binary + flowgger.toml for every target in the Travis CI build. I also did some refactoring to the Travis scripts.

Example release: https://github.com/Trojan295/flowgger/releases/tag/0.1.0
Travis CI build for this release: https://travis-ci.org/Trojan295/flowgger/builds/600116381

**To make it work, some Github account with rights to publish to Github Releases must generate an API key and add to Travis CI environment variables as `GITHUB_APIKEY`.**

I also added to test/build the flowgger binary with all features except `capnp`, because it requires the capnp compiler installed in the build environment. We cannot install it there, because we are using cross and would need to build custom images for every target (see https://github.com/rust-embedded/cross/issues/281).

I also had to modify two tests for `FileOutput`, because they were writing a file to a path, which is read-only in the build environment and thus failing. There are also additional modification to this file, caused by `cargo fmt`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
