### PR TITLE
Update dependency for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rfc5424=[]
 file = ["notify", "glob"]
 
 [build-dependencies.capnpc]
-version = "*"
+version = "0.10"
 optional = true
 
 [dependencies]


### PR DESCRIPTION
*Issue #32 

Cargo publish does not accept wildcard dependencies, specifies capnpc version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
