### PR TITLE
Add more format handling to rfc3164, and passthrough output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "flowgger"
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Frank Denis <github@pureftpd.org>", "Matteo Bigoi <bigo@crisidev.org>", "Vivien Chene <viv.chene@gmail.com>", "Francesco Berni <kurojishi@kurojishi.me>"]
 build = "build.rs"
 repository = "https://github.com/awslabs/flowgger"
@@ -26,9 +26,10 @@ kafka-output = ["kafka"]
 tls = ["openssl"]
 gelf = ["serde", "serde_json"]
 ltsv = []
-syslog = ["rfc5424", "rfc3164"]
+syslog = ["rfc5424", "rfc3164", "passthrough"]
 rfc3164=[]
 rfc5424=[]
+passthrough=[]
 file = ["notify", "glob"]
 
 [build-dependencies.capnpc]
@@ -38,6 +39,7 @@ optional = true
 [dependencies]
 capnp = { version = "0.10", optional = true }
 chrono = "0.4"
+chrono-tz = "0.5"
 clap = "2"
 flate2 = "1"
 glob = { version = "0.3", optional = true }

--- a/flowgger.toml
+++ b/flowgger.toml
@@ -155,6 +155,7 @@ file_rotation_timeformat = "%Y%m%dT%H%M%SZ"
 
 ### Syslog
 framing = "line"
+# "rfc3164" or "rfc5424" or "passthrough"
 format = "rfc3164"
 # Format of the optional timestamp to be prepended to each event
-rfc3164_prepend_timestamp="[%Y-%m-%dT%H:%M:%S%.6fZ]"
+syslog_prepend_timestamp="[%Y-%m-%dT%H:%M:%S%.6fZ]"

--- a/src/flowgger/decoder/ltsv_decoder.rs
+++ b/src/flowgger/decoder/ltsv_decoder.rs
@@ -213,7 +213,7 @@ impl Decoder for LTSVDecoder {
             msgid: None,
             sd: if sd.pairs.is_empty() { None } else { Some(sd) },
             msg,
-            full_msg: None,
+            full_msg: Some(line.to_owned()),
         };
         Ok(record)
     }

--- a/src/flowgger/decoder/rfc3164_decoder.rs
+++ b/src/flowgger/decoder/rfc3164_decoder.rs
@@ -53,7 +53,7 @@ struct Pri {
 }
 
 fn decode_rfc_standard(pri: &Pri, msg: &str, line: &str) -> Result<Record, &'static str> {
-    // Decoding "usual" rfc input as advised in the rfc: [<pri>]<datetime> <hostname> <message>
+    // Decoding "recommended" rfc input as advised in the rfc: [<pri>]<datetime> <hostname> <message>
 
     // The event may have several consecutive spaces as separator
     let tokens_vec = msg.split_whitespace().collect::<Vec<&str>>();

--- a/src/flowgger/decoder/rfc3164_decoder.rs
+++ b/src/flowgger/decoder/rfc3164_decoder.rs
@@ -2,7 +2,9 @@ use super::Decoder;
 use crate::flowgger::config::Config;
 use crate::flowgger::record::Record;
 use crate::flowgger::utils;
-use chrono::{Datelike, NaiveDateTime, Utc};
+use chrono::{Datelike, NaiveDateTime, TimeZone, Utc};
+use chrono_tz::Tz;
+use std::io::{stderr, Write};
 
 #[derive(Clone)]
 pub struct RFC3164Decoder {}
@@ -14,7 +16,10 @@ impl RFC3164Decoder {
 }
 
 impl Decoder for RFC3164Decoder {
-    /// Implementation of the RF3164 decoder. Decode a string into a record object
+    /// Implementation of the RF3164 decoder. Decode a string into a record object.alloc
+    /// RFC3164 is quite lenient and allow many different implementation.
+    /// This decoder starts decoding the most common format, as exampled provided in RFC.
+    /// If this fails, device specific implementations are looked for.
     ///
     /// # Arguments
     /// * `line` - String to decode
@@ -26,41 +31,93 @@ impl Decoder for RFC3164Decoder {
         // Get the optional pri part and remove it from the string
         let (pri, _msg) = parse_strip_pri(line)?;
 
-        // The event may have several consecutive spaces as separator
-        let tokens_vec = _msg.split_whitespace().collect::<Vec<&str>>();
-
-        // If we have less than 4 tokens, the input can't be valid
-        if tokens_vec.len() > 3 {
-            // Date is made of the first 3 space separated tokens, rebuild it
-            let _date_str = tokens_vec[0..3].join(" ");
-            let _hostname = tokens_vec[3];
-
-            // All that remains is the message that may contain several spaces, so rebuild it
-            let _message = tokens_vec[4..].join(" ");
-
-            let ts = parse_ts(&_date_str)?;
-            let record = Record {
-                ts,
-                hostname: _hostname.to_owned(),
-                facility: pri.facility,
-                severity: pri.severity,
-                appname: None,
-                procid: None,
-                msgid: None,
-                msg: Some(_message.to_owned()),
-                full_msg: Some(line.to_owned()),
-                sd: None,
-            };
-            Ok(record)
-        } else {
-            Err("Malformed RFC3164 event: Invalid timestamp or hostname")
+        let mut res = decode_rfc_standard(&pri, _msg, line);
+        if let Ok (record) = res  {
+            return Ok(record);
         }
+
+        // Specific implementation
+        res = decode_rfc_custom(&pri, _msg, line);
+        if let Ok (record) = res  {
+            return Ok(record);
+        }
+
+        let _ = writeln!(stderr(), "Unable to parse the rfc3164 input: '{}'", line);
+        res
     }
 }
 
 struct Pri {
     facility: Option<u8>,
     severity: Option<u8>,
+}
+
+fn decode_rfc_standard(pri: &Pri, msg: &str, line: &str) -> Result<Record, &'static str> {
+    // Decoding "usual" rfc input as advised in the rfc: [<pri>]<datetime> <hostname> <message>
+
+    // The event may have several consecutive spaces as separator
+    let tokens_vec = msg.split_whitespace().collect::<Vec<&str>>();
+
+    // If we have less than 4 tokens, the input can't be valid
+    if tokens_vec.len() > 3 {
+        // Parse the date, the next token is the hostname
+        let (ts, _log_tokens) = parse_date_token(&tokens_vec)?;
+        let _hostname = _log_tokens[0];
+
+        // All that remains is the message that may contain several spaces, so rebuild it
+        let _message = _log_tokens[1..].join(" ");
+
+        let record = Record {
+            ts,
+            hostname: _hostname.to_owned(),
+            facility: pri.facility,
+            severity: pri.severity,
+            appname: None,
+            procid: None,
+            msgid: None,
+            msg: Some(_message.to_owned()),
+            full_msg: Some(line.to_owned()),
+            sd: None,
+        };
+        Ok(record)
+    } else {
+        Err("Malformed RFC3164 standard event: Invalid timestamp or hostname")
+    }
+}
+
+fn decode_rfc_custom(pri: &Pri, msg: &str, line: &str) -> Result<Record, &'static str> {
+    // Decoding custom rfc input formatted as : [<pri>]<hostname>: <datetime>: <message>
+
+    // The event separator for hostname/timestamp/message is ": "
+    let tokens_vec = msg.split(": ").collect::<Vec<&str>>();
+
+    // If we have less than 2 tokens, the input can't be valid
+    if tokens_vec.len() > 2 {
+        let _hostname = tokens_vec[0];
+
+        // The date is space separated, but make sure to remove consecutive spaces
+        let date_tokens_vec = tokens_vec[1].split_whitespace().collect::<Vec<&str>>();
+        let (ts, _) = parse_date_token(&date_tokens_vec)?;
+
+        // All that remains is the message, rebuild it
+        let _message = tokens_vec[2..].join(": ");
+
+        let record = Record {
+            ts,
+            hostname: _hostname.to_owned(),
+            facility: pri.facility,
+            severity: pri.severity,
+            appname: None,
+            procid: None,
+            msgid: None,
+            msg: Some(_message.to_owned()),
+            full_msg: Some(line.to_owned()),
+            sd: None,
+        };
+        Ok(record)
+    } else {
+        Err("Malformed RFC3164 event: Invalid timestamp or hostname")
+    }
 }
 
 fn parse_strip_pri(event: &str) -> Result<(Pri, &str), &'static str> {
@@ -92,22 +149,60 @@ fn parse_strip_pri(event: &str) -> Result<(Pri, &str), &'static str> {
     }
 }
 
-fn parse_ts(ts_str: &str) -> Result<f64, &'static str> {
-    // Append the year to parse a full ts
-    let current_year = Utc::now().year();
-    let ts = format!("{} {}", current_year, ts_str);
+fn parse_date_token<'a>(ts_tokens: &'a [&str]) -> Result<(f64, Vec<&'a str>), &'static str> {
+    // If we don't have at least 3 tokens, don't even try, parsing will fail
+    if ts_tokens.len() < 3 {
+        return Err("Invalid time format");
+    }
+    // Decode the date/time without year (expected), and if it fails, try  add the year
+    parse_date(ts_tokens, false).or_else(|_| parse_date(ts_tokens, true))
+}
 
-    match NaiveDateTime::parse_from_str(&ts, "%Y %b %d %H:%M:%S") {
-        Ok(date) => Ok(utils::PreciseTimestamp::from_naive_datetime(date).as_f64()),
-        Err(_) => Err("Unable to parse the date"),
+fn parse_date<'a>(ts_tokens: &'a [&str], has_year: bool) -> Result<(f64, Vec<&'a str>), &'static str> {
+    // Decode the date/time from the given tokens with optional year specified
+    let ts_str;
+    let mut idx;
+
+    // If no year in the string, parse manually add the current year
+    if has_year {
+        idx = 4;
+        ts_str = ts_tokens[0..idx].join(" ");
+    }
+    else {
+        idx = 3;
+        let current_year = Utc::now().year();
+        ts_str = format!("{} {}", current_year, ts_tokens[0..idx].join(" "));
+    }
+
+    match NaiveDateTime::parse_from_str(&ts_str, "%Y %b %d %H:%M:%S") {
+        Ok(naive_dt) => {
+            // See if the next token is a timezone
+            let mut ts = 0.0;
+            let tz_res: Result<Tz, String> = if ts_tokens.len() > idx { ts_tokens[idx].parse() } else { Err("No timezone".to_string()) };
+            if let Ok(tz) = tz_res {
+                let dt = tz.from_local_datetime(&naive_dt).single();
+                if dt.is_some() {
+                    ts = utils::PreciseTimestamp::from_datetime_tz(dt.unwrap()).as_f64();
+                    idx += 1;
+                }
+            }
+            // No timezome, give a timestamp without tz
+            else {
+                ts = utils::PreciseTimestamp::from_naive_datetime(naive_dt).as_f64();
+            }
+            Ok((ts, ts_tokens[idx..].to_vec()))
+        },
+        Err(_err) => {
+            Err("Unable to parse date")
+        }
     }
 }
 
 #[cfg(test)]
-use crate::flowgger::utils::test_utils::rfc_test_utils::ts_from_partial_date_time;
+use crate::flowgger::utils::test_utils::rfc_test_utils::{ts_from_partial_date_time, ts_from_date_time};
 
 #[test]
-fn test_rfc3164_decode() {
+fn test_rfc3164_decode_nopri() {
     let msg = r#"Aug  6 11:15:24 testhostname appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#;
     let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"rfc3164\"\n").unwrap();
     let expected_ts = ts_from_partial_date_time(8, 6, 11, 15, 24);
@@ -145,6 +240,63 @@ fn test_rfc3164_decode_with_pri() {
 }
 
 #[test]
+fn test_rfc3164_decode_with_pri_year() {
+    let msg = r#"<13>2020 Aug  6 11:15:24 testhostname appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#;
+    let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"rfc3164\"\n").unwrap();
+    let expected_ts = ts_from_date_time(2020, 8, 6, 11, 15, 24, 0);
+
+    let decoder = RFC3164Decoder::new(&cfg);
+    let res = decoder.decode(msg).unwrap();
+    assert_eq!(res.facility, Some(1));
+    assert_eq!(res.severity, Some(5));
+    assert_eq!(res.ts, expected_ts);
+    assert_eq!(res.hostname, "testhostname");
+    assert_eq!(res.appname, None);
+    assert_eq!(res.procid, None);
+    assert_eq!(res.msgid, None);
+    assert_eq!(res.msg, Some(r#"appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#.to_string()));
+    assert_eq!(res.full_msg, Some(msg.to_string()));
+}
+
+#[test]
+fn test_rfc3164_decode_with_pri_year_tz() {
+    let msg = r#"<13>2020 Aug  6 11:15:24 UTC testhostname appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#;
+    let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"rfc3164\"\n").unwrap();
+    let expected_ts = ts_from_date_time(2020, 8, 6, 11, 15, 24, 0);
+
+    let decoder = RFC3164Decoder::new(&cfg);
+    let res = decoder.decode(msg).unwrap();
+    assert_eq!(res.facility, Some(1));
+    assert_eq!(res.severity, Some(5));
+    assert_eq!(res.ts, expected_ts);
+    assert_eq!(res.hostname, "testhostname");
+    assert_eq!(res.appname, None);
+    assert_eq!(res.procid, None);
+    assert_eq!(res.msgid, None);
+    assert_eq!(res.msg, Some(r#"appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#.to_string()));
+    assert_eq!(res.full_msg, Some(msg.to_string()));
+}
+
+#[test]
+fn test_rfc3164_decode_tz_no_year() {
+    let msg = r#"Aug  6 11:15:24 UTC testhostname appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#;
+    let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"rfc3164\"\n").unwrap();
+    let expected_ts = ts_from_partial_date_time(8, 6, 11, 15, 24);
+
+    let decoder = RFC3164Decoder::new(&cfg);
+    let res = decoder.decode(msg).unwrap();
+    assert_eq!(res.facility, None);
+    assert_eq!(res.severity, None);
+    assert_eq!(res.ts, expected_ts);
+    assert_eq!(res.hostname, "testhostname");
+    assert_eq!(res.appname, None);
+    assert_eq!(res.procid, None);
+    assert_eq!(res.msgid, None);
+    assert_eq!(res.msg, Some(r#"appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#.to_string()));
+    assert_eq!(res.full_msg, Some(msg.to_string()));
+}
+
+#[test]
 fn test_rfc3164_decode_invalid_event() {
     let msg = "test message";
     let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"rfc3164\"\n").unwrap();
@@ -162,4 +314,63 @@ fn test_rfc3164_decode_invalid_date() {
     let decoder = RFC3164Decoder::new(&cfg);
     let res = decoder.decode(msg);
     assert!(res.is_err());
+}
+
+#[test]
+fn test_rfc3164_decode_custom_with_year() {
+    // let msg = r#"testhostname: 2019 Mar 27 12:09:39 UTC:  appname: test message"#;
+    let msg = r#"testhostname: 2020 Aug  6 11:15:24 UTC: appname 69 42 some test message"#;
+    let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"rfc3164\"\n").unwrap();
+    // let expected_ts = ts_from_date_time(2019, 3, 27, 12, 9, 39, 0);
+    let expected_ts = ts_from_date_time(2020, 8, 6, 11, 15, 24, 0);
+
+    let decoder = RFC3164Decoder::new(&cfg);
+    let res = decoder.decode(msg).unwrap();
+    assert_eq!(res.facility, None);
+    assert_eq!(res.severity, None);
+    assert_eq!(res.ts, expected_ts);
+    assert_eq!(res.hostname, "testhostname");
+    assert_eq!(res.appname, None);
+    assert_eq!(res.procid, None);
+    assert_eq!(res.msgid, None);
+    assert_eq!(res.msg, Some(r#"appname 69 42 some test message"#.to_string()));
+    assert_eq!(res.full_msg, Some(msg.to_string()));
+}
+
+#[test]
+fn test_rfc3164_decode_custom_with_year_notz() {
+    let msg = r#"testhostname: 2019 Mar 27 12:09:39: appname: a test message"#;
+    let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"rfc3164\"\n").unwrap();
+    let expected_ts = ts_from_date_time(2019, 3, 27, 12, 9, 39, 0);
+
+    let decoder = RFC3164Decoder::new(&cfg);
+    let res = decoder.decode(msg).unwrap();
+    assert_eq!(res.facility, None);
+    assert_eq!(res.severity, None);
+    assert_eq!(res.ts, expected_ts);
+    assert_eq!(res.hostname, "testhostname");
+    assert_eq!(res.appname, None);
+    assert_eq!(res.procid, None);
+    assert_eq!(res.msgid, None);
+    assert_eq!(res.msg, Some(r#"appname: a test message"#.to_string()));
+    assert_eq!(res.full_msg, Some(msg.to_string()));
+}
+
+#[test]
+fn test_rfc3164_decode_custom_with_pri() {
+    let msg = r#"<13>testhostname: 2019 Mar 27 12:09:39 UTC: appname: test message"#;
+    let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"rfc3164\"\n").unwrap();
+    let expected_ts = ts_from_date_time(2019, 3, 27, 12, 9, 39, 0);
+
+    let decoder = RFC3164Decoder::new(&cfg);
+    let res = decoder.decode(msg).unwrap();
+    assert_eq!(res.facility, Some(1));
+    assert_eq!(res.severity, Some(5));
+    assert_eq!(res.ts, expected_ts);
+    assert_eq!(res.hostname, "testhostname");
+    assert_eq!(res.appname, None);
+    assert_eq!(res.procid, None);
+    assert_eq!(res.msgid, None);
+    assert_eq!(res.msg, Some(r#"appname: test message"#.to_string()));
+    assert_eq!(res.full_msg, Some(msg.to_string()));
 }

--- a/src/flowgger/encoder/mod.rs
+++ b/src/flowgger/encoder/mod.rs
@@ -8,6 +8,8 @@ mod ltsv_encoder;
 mod rfc3164_encoder;
 #[cfg(feature = "rfc5424")]
 mod rfc5424_encoder;
+#[cfg(feature = "passthrough")]
+mod passthrough_encoder;
 
 #[cfg(feature = "capnp-recompile")]
 pub use self::capnp_encoder::CapnpEncoder;
@@ -19,8 +21,12 @@ pub use self::ltsv_encoder::LTSVEncoder;
 pub use self::rfc3164_encoder::RFC3164Encoder;
 #[cfg(feature = "rfc5424")]
 pub use self::rfc5424_encoder::RFC5424Encoder;
+#[cfg(feature = "passthrough")]
+pub use self::passthrough_encoder::PassthroughEncoder;
 
 use crate::flowgger::record::Record;
+use chrono::Utc;
+use crate::flowgger::config::Config;
 
 pub trait CloneBoxedEncoder {
     fn clone_boxed<'a>(&self) -> Box<dyn Encoder + Send + 'a>
@@ -45,4 +51,20 @@ impl Clone for Box<dyn Encoder> {
 
 pub trait Encoder: CloneBoxedEncoder {
     fn encode(&self, record: Record) -> Result<Vec<u8>, &'static str>;
+}
+
+pub fn config_get_prepend_ts(config: &Config) -> Option<String> {
+    config
+        .lookup("output.syslog_prepend_timestamp")
+        .map_or(None, |bs| {
+            Some(bs.as_str()
+                .expect("output.syslog_prepend_timestamp should be a string")
+                .to_string())
+        })
+}
+
+pub fn build_prepend_ts(format_str: &str) -> String {
+    let current_time  = Utc::now();
+    // let format_str: &str = format.as_ref().unwrap();
+    current_time.format(format_str).to_string()
 }

--- a/src/flowgger/encoder/passthrough_encoder.rs
+++ b/src/flowgger/encoder/passthrough_encoder.rs
@@ -1,0 +1,121 @@
+use super::{Encoder, config_get_prepend_ts, build_prepend_ts};
+use crate::flowgger::config::Config;
+use crate::flowgger::record::Record;
+
+#[derive(Clone)]
+pub struct PassthroughEncoder {
+    header_time_format: Option<String>,
+}
+
+impl PassthroughEncoder {
+    pub fn new(config: &Config) -> PassthroughEncoder {
+        let header_time_format = config_get_prepend_ts(config);
+        PassthroughEncoder { header_time_format }
+    }
+}
+
+impl Encoder for PassthroughEncoder {
+    /// Implementation of a passthrough encoder.
+    /// Just pass the full raw messages from input without rebuilding them.
+    /// This allows passing several different formats, i.e. rfc3164 can accept different formats.
+    /// The actual output format is therefore the format set set as input.
+    fn encode(&self, record: Record) -> Result<Vec<u8>, &'static str> {
+        let mut res = String::new();
+
+        // Only push messages where the raw message is specified
+        if let Some(msg) = record.full_msg {
+            // First, if specified, prepend a header
+            if self.header_time_format.is_some() {
+                res.push_str(&build_prepend_ts(self.header_time_format.as_ref().unwrap()));
+            }
+
+            // Pysh the message
+            res.push_str(&msg);
+            Ok(res.into_bytes())
+        }
+        else {
+            Err("Cannot output empty raw message")
+        }
+    }
+}
+
+#[cfg(test)]
+use chrono::Utc;
+
+#[test]
+fn test_passthrough_encode() {
+    let expected_msg = r#"Aug  6 11:15:24 testhostname appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#;
+    let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"passthrough\"\n").unwrap();
+
+    let record = Record {
+        ts:1.2,
+        hostname: "abcd".to_string(),
+        facility: None,
+        severity: None,
+        appname: None,
+        procid: None,
+        msgid: None,
+        msg: Some(r#"test message"#.to_string()),
+        full_msg: Some(expected_msg.to_string()),
+        sd: None,
+    };
+
+    let encoder = PassthroughEncoder::new(&cfg);
+    let res = encoder.encode(record).unwrap();
+    assert_eq!(String::from_utf8_lossy(&res), expected_msg);
+}
+
+#[test]
+fn test_passthrough_encode_with_prepend() {
+    let cfg = Config::from_string("[output]\nformat = \"passthrough\"\nsyslog_prepend_timestamp=\"[%Y-%m-%dT%H:%MZ]\"").unwrap();
+    let dt = Utc::now();
+    let dt_str = dt.format("[%Y-%m-%dT%H:%MZ]").to_string();
+    let input_msg = format!(r#"{}Aug  6 11:15:24 testhostname appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#, dt_str);
+    let expected_msg = format!(r#"{}{}"#, dt_str, input_msg);
+
+    let record = Record {
+        ts: 1.2,
+        hostname: "abcd".to_string(),
+        facility: None,
+        severity: None,
+        appname: None,
+        procid: None,
+        msgid: None,
+        msg: Some(r#"test message"#.to_string()),
+        full_msg: Some(input_msg.to_string()),
+        sd: None,
+    };
+
+    let encoder = PassthroughEncoder::new(&cfg);
+    let res = encoder.encode(record).unwrap();
+    assert_eq!(String::from_utf8_lossy(&res), expected_msg);
+}
+
+#[test]
+#[should_panic(expected = "output.syslog_prepend_timestamp should be a string")]
+fn test_passthrough_encode_invalid_prepend() {
+    let cfg = Config::from_string("[output]\nformat = \"passthrough\"\nsyslog_prepend_timestamp=123").unwrap();
+    let _ = PassthroughEncoder::new(&cfg);
+}
+
+#[test]
+#[should_panic(expected = "Cannot output empty raw message")]
+fn test_passthrough_encode_no_msg() {
+    let cfg = Config::from_string("[output]\nformat = \"passthrough\"\nsyslog_prepend_timestamp=\"[%Y-%m-%dT%H:%MZ]\"").unwrap();
+
+    let record = Record {
+        ts: 1.2,
+        hostname: "abcd".to_string(),
+        facility: None,
+        severity: None,
+        appname: None,
+        procid: None,
+        msgid: None,
+        msg: Some(r#"test message"#.to_string()),
+        full_msg: None,
+        sd: None,
+    };
+
+    let encoder = PassthroughEncoder::new(&cfg);
+    let _ = encoder.encode(record).unwrap();
+}

--- a/src/flowgger/mod.rs
+++ b/src/flowgger/mod.rs
@@ -11,6 +11,7 @@ mod utils;
 #[cfg(feature = "capnp-recompile")]
 extern crate capnp;
 extern crate chrono;
+extern crate chrono_tz;
 extern crate clap;
 extern crate flate2;
 #[cfg(feature = "file")]
@@ -49,6 +50,8 @@ use self::encoder::LTSVEncoder;
 use self::encoder::RFC3164Encoder;
 #[cfg(feature = "rfc5424")]
 use self::encoder::RFC5424Encoder;
+#[cfg(feature = "passthrough")]
+use self::encoder::PassthroughEncoder;
 #[cfg(feature = "file")]
 use self::input::FileInput;
 #[cfg(feature = "redis-input")]
@@ -266,6 +269,11 @@ fn get_encoder_rfc5424(config: &Config) -> Box<dyn Encoder + Send> {
     Box::new(RFC5424Encoder::new(config)) as Box<dyn Encoder + Send>
 }
 
+#[cfg(feature = "passthrough")]
+fn get_encoder_passthrough(config: &Config) -> Box<dyn Encoder + Send> {
+    Box::new(PassthroughEncoder::new(config)) as Box<dyn Encoder + Send>
+}
+
 #[cfg(feature = "rfc3164")]
 fn get_decoder_rfc3164(config: &Config) -> Box<dyn Decoder + Send> {
     Box::new(RFC3164Decoder::new(config)) as Box<dyn Decoder + Send>
@@ -294,6 +302,11 @@ fn get_encoder_rfc3164(_config: &Config) -> ! {
 #[cfg(not(feature = "rfc3164"))]
 fn get_encoder_rfc5424(_config: &Config) -> ! {
     panic!("Support for rfc3164 hasn't been compiled in")
+}
+
+#[cfg(not(feature = "passthrough"))]
+fn get_encoder_passthrough(_config: &Config) -> ! {
+    panic!("Support for passthrough hasn't been compiled in")
 }
 
 pub fn start(config_file: &str) {
@@ -336,6 +349,7 @@ pub fn start(config_file: &str) {
         "ltsv" => get_ltvs_encoder(&config),
         "rfc3164" => get_encoder_rfc3164(&config),
         "rfc5424" => get_encoder_rfc5424(&config),
+        "passthrough" => get_encoder_passthrough(&config),
         _ => panic!("Unknown output format: {}", output_format),
     };
     let output_type = config

--- a/src/flowgger/utils/mod.rs
+++ b/src/flowgger/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod rotating_file;
 pub mod test_utils;
 
 use chrono::{DateTime, FixedOffset, NaiveDateTime, Timelike};
+use chrono_tz::Tz;
 #[cfg(feature = "gelf")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -29,6 +30,13 @@ impl PreciseTimestamp {
 
     #[inline]
     pub fn from_datetime(tsd: DateTime<FixedOffset>) -> Self {
+        PreciseTimestamp {
+            ts: tsd.timestamp() as f64 + f64::from(tsd.naive_utc().nanosecond()) / 1e9,
+        }
+    }
+
+    #[inline]
+    pub fn from_datetime_tz(tsd: DateTime<Tz>) -> Self {
         PreciseTimestamp {
             ts: tsd.timestamp() as f64 + f64::from(tsd.naive_utc().nanosecond()) / 1e9,
         }


### PR DESCRIPTION
RFC3164 is very wide, and many (if not an) log format are allowed.
This pull requests improves the format accepted:
- date can optionally have the year specified
- date can optionally have the timezone name specified (i.e. UTC, PST, or any in the IANA database)
- device specific formats can be added. One added is where hostname is specified in first position

A passthrough output module has also been added. When using RFC3164 for instance, it allows pushing events received in different format while conserving them, rather than reformating them in a common format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
