### PR TITLE
Support multiple SD in RFC5424 (fix issue #61)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "flowgger"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Frank Denis <github@pureftpd.org>", "Matteo Bigoi <bigo@crisidev.org>", "Vivien Chene <viv.chene@gmail.com>", "Francesco Berni <kurojishi@kurojishi.me>"]
 build = "build.rs"
 repository = "https://github.com/awslabs/flowgger"

--- a/src/flowgger/decoder/gelf_decoder.rs
+++ b/src/flowgger/decoder/gelf_decoder.rs
@@ -113,7 +113,7 @@ impl Decoder for GelfDecoder {
             appname: None,
             procid: None,
             msgid: None,
-            sd: if sd.pairs.is_empty() { None } else { Some(sd) },
+            sd: if sd.pairs.is_empty() { None } else { Some(vec![sd]) },
             msg,
             full_msg,
         };
@@ -136,8 +136,9 @@ mod test {
         assert!(res.full_msg.unwrap() == "Backtrace here\n\nmore stuff");
         assert!(res.severity.unwrap() == 1);
 
-        let sd = res.sd.unwrap();
-        let pairs = sd.pairs;
+        let sd = &res.sd.unwrap();
+        assert!(sd.len() == 1);
+        let pairs = &sd[0].pairs;
         assert!(pairs
             .iter()
             .cloned()

--- a/src/flowgger/decoder/ltsv_decoder.rs
+++ b/src/flowgger/decoder/ltsv_decoder.rs
@@ -40,10 +40,10 @@ impl LTSVDecoder {
                         "f64" => SDValueType::F64,
                         "i64" => SDValueType::I64,
                         "u64" => SDValueType::U64,
-                        _ => panic!(format!(
+                        _ => panic!(
                             "Unsupported type in input.ltsv_schema for name [{}]",
                             name
-                        )),
+                        ),
                     };
                     schema.insert(name.to_owned(), sdtype);
                 }
@@ -73,10 +73,10 @@ impl LTSVDecoder {
                         "f64" => suffixes.s_f64 = Some(suffix),
                         "i64" => suffixes.s_i64 = Some(suffix),
                         "u64" => suffixes.s_u64 = Some(suffix),
-                        _ => panic!(format!(
+                        _ => panic!(
                             "Unsupported type in input.ltsv_suffixes for type [{}]",
                             sdtype
-                        )),
+                        ),
                     }
                 }
             }
@@ -211,7 +211,7 @@ impl Decoder for LTSVDecoder {
             appname: None,
             procid: None,
             msgid: None,
-            sd: if sd.pairs.is_empty() { None } else { Some(sd) },
+            sd: if sd.pairs.is_empty() { None } else { Some(vec![sd]) },
             msg,
             full_msg: Some(line.to_owned()),
         };
@@ -259,8 +259,8 @@ fn test_ltsv_suffixes() {
                -0700]\tdone:true\tscore:-1\tmean:0.42\tcounter:42\tlevel:3\thost:\
                testhostname\tname1:value1\tname 2: value 2\tn3:v3\tmessage:this is a test";
     let res = ltsv_decoder.decode(msg).unwrap();
-    let sd = res.sd.unwrap();
-    let pairs = sd.pairs;
+    let sd = &res.sd.unwrap()[0];
+    let pairs = &sd.pairs;
     assert!(pairs
         .iter()
         .cloned()
@@ -309,8 +309,8 @@ fn test_ltsv_suffixes_2() {
                -0700]\tdone_bool:true\tscore_i64:-1\tmean_f64:0.42\tcounter_u64:42\tlevel:3\thost:\
                testhostname\tname1:value1\tname 2: value 2\tn3:v3\tmessage:this is a test";
     let res = ltsv_decoder.decode(msg).unwrap();
-    let sd = res.sd.unwrap();
-    let pairs = sd.pairs;
+    let sd = &res.sd.unwrap()[0];
+    let pairs = &sd.pairs;
     assert!(pairs
         .iter()
         .cloned()
@@ -388,8 +388,11 @@ fn test_ltsv_3() {
 
     assert!(res.hostname == "testhostname");
     assert!(res.msg.unwrap() == "this is a test");
-    let sd = res.sd.unwrap();
-    let pairs = sd.pairs;
+
+    let sd = &res.sd.unwrap();
+    assert!(sd.len() == 1);
+    let pairs = &sd[0].pairs;
+
     assert!(pairs
         .iter()
         .cloned()

--- a/src/flowgger/decoder/rfc3164_decoder.rs
+++ b/src/flowgger/decoder/rfc3164_decoder.rs
@@ -218,6 +218,7 @@ fn test_rfc3164_decode_nopri() {
     assert_eq!(res.msgid, None);
     assert_eq!(res.msg, Some(r#"appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#.to_string()));
     assert_eq!(res.full_msg, Some(msg.to_string()));
+    assert!(res.sd.is_none());
 }
 
 #[test]
@@ -237,6 +238,7 @@ fn test_rfc3164_decode_with_pri() {
     assert_eq!(res.msgid, None);
     assert_eq!(res.msg, Some(r#"appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#.to_string()));
     assert_eq!(res.full_msg, Some(msg.to_string()));
+    assert!(res.sd.is_none());
 }
 
 #[test]
@@ -256,6 +258,7 @@ fn test_rfc3164_decode_with_pri_year() {
     assert_eq!(res.msgid, None);
     assert_eq!(res.msg, Some(r#"appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#.to_string()));
     assert_eq!(res.full_msg, Some(msg.to_string()));
+    assert!(res.sd.is_none());
 }
 
 #[test]
@@ -275,6 +278,7 @@ fn test_rfc3164_decode_with_pri_year_tz() {
     assert_eq!(res.msgid, None);
     assert_eq!(res.msg, Some(r#"appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#.to_string()));
     assert_eq!(res.full_msg, Some(msg.to_string()));
+    assert!(res.sd.is_none());
 }
 
 #[test]
@@ -294,6 +298,7 @@ fn test_rfc3164_decode_tz_no_year() {
     assert_eq!(res.msgid, None);
     assert_eq!(res.msg, Some(r#"appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#.to_string()));
     assert_eq!(res.full_msg, Some(msg.to_string()));
+    assert!(res.sd.is_none());
 }
 
 #[test]
@@ -335,6 +340,7 @@ fn test_rfc3164_decode_custom_with_year() {
     assert_eq!(res.msgid, None);
     assert_eq!(res.msg, Some(r#"appname 69 42 some test message"#.to_string()));
     assert_eq!(res.full_msg, Some(msg.to_string()));
+    assert!(res.sd.is_none());
 }
 
 #[test]
@@ -354,6 +360,7 @@ fn test_rfc3164_decode_custom_with_year_notz() {
     assert_eq!(res.msgid, None);
     assert_eq!(res.msg, Some(r#"appname: a test message"#.to_string()));
     assert_eq!(res.full_msg, Some(msg.to_string()));
+    assert!(res.sd.is_none());
 }
 
 #[test]
@@ -373,6 +380,7 @@ fn test_rfc3164_decode_custom_with_pri() {
     assert_eq!(res.msgid, None);
     assert_eq!(res.msg, Some(r#"appname: test message"#.to_string()));
     assert_eq!(res.full_msg, Some(msg.to_string()));
+    assert!(res.sd.is_none());
 }
 
 #[test]
@@ -391,4 +399,5 @@ fn test_rfc3164_decode_custom_trimed() {
     assert_eq!(res.procid, None);
     assert_eq!(res.msgid, None);
     assert_eq!(res.full_msg, Some("<13>testhostname: 2019 Mar 27 12:09:39 UTC: appname: test message".to_string()));
+    assert!(res.sd.is_none());
 }

--- a/src/flowgger/encoder/capnp_encoder.rs
+++ b/src/flowgger/encoder/capnp_encoder.rs
@@ -74,22 +74,25 @@ fn build_record<T: Allocator>(
     if let Some(full_msg) = record.full_msg {
         root.set_full_msg(&full_msg);
     }
-    if let Some(sd) = record.sd {
+    if let Some(sd_vec) = record.sd {
+        // Warning: the current capnp format only support one structured data. Redefining the
+        // format would be a breaking change.
+        let sd = &sd_vec[0];
         sd.sd_id.as_ref().and_then(|sd_id| {
             root.set_sd_id(sd_id);
             Some(())
         });
         let mut pairs = root.reborrow().init_pairs(sd.pairs.len() as u32);
-        for (i, (name, value)) in sd.pairs.into_iter().enumerate() {
+        for (i, (name, value)) in (&sd.pairs).into_iter().enumerate() {
             let mut pair = pairs.reborrow().get(i as u32);
             pair.set_key(&name);
             let mut v = pair.init_value();
             match value {
                 SDValue::String(value) => v.set_string(&value),
-                SDValue::Bool(value) => v.set_bool(value),
-                SDValue::F64(value) => v.set_f64(value),
-                SDValue::I64(value) => v.set_i64(value),
-                SDValue::U64(value) => v.set_u64(value),
+                SDValue::Bool(value) => v.set_bool(*value),
+                SDValue::F64(value) => v.set_f64(*value),
+                SDValue::I64(value) => v.set_i64(*value),
+                SDValue::U64(value) => v.set_u64(*value),
                 SDValue::Null => v.set_null(()),
             };
         }
@@ -129,7 +132,7 @@ mod tests {
             msgid: None,
             msg: Some("A short message that helps you identify what is going on".to_string()),
             full_msg: Some("Backtrace here\n\nmore stuff".to_string()),
-            sd: Some(sd),
+            sd: Some(vec![sd]),
         };
 
         assert_eq!(
@@ -167,6 +170,40 @@ mod tests {
         assert_eq!(
             String::from_utf8_lossy(&encoder.encode(record).unwrap()),
             "\u{0}\u{0}\u{0}\u{0}%\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{2}\u{0}\t\u{0}*������A�\u{1}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}!\u{0}\u{0}\u{0}b\u{0}\u{0}\u{0}%\u{0}\u{0}\u{0}B\u{0}\u{0}\u{0}%\u{0}\u{0}\u{0}\u{1a}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}!\u{0}\u{0}\u{0}�\u{1}\u{0}\u{0}=\u{0}\u{0}\u{0}�\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}A\u{0}\u{0}\u{0}\'\u{0}\u{0}\u{0}example.org\u{0}\u{0}\u{0}\u{0}\u{0}appname\u{0}44\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}A short message that helps you identify what is going on\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}Backtrace here\n\nmore stuff\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{4}\u{0}\u{0}\u{0}\u{2}\u{0}\u{2}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{5}\u{0}\u{0}\u{0}R\u{0}\u{0}\u{0}\t\u{0}\u{0}\u{0}r\u{0}\u{0}\u{0}x-header1\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}header1 value\u{0}\u{0}\u{0}"
+        );
+    }
+
+    #[test]
+    fn test_capnp_encode_multiple_sd() {
+        let config = Config::from_string("").unwrap();
+        let encoder = CapnpEncoder::new(&config);
+
+        let sd_vec = vec![
+            StructuredData {
+                sd_id: Some("someid".to_string()),
+                pairs: vec![("_some_info".to_string(), SDValue::String("foo".to_string()))],
+            },
+            StructuredData {
+                sd_id: Some("someid2".to_string()),
+                pairs: vec![("info".to_string(), SDValue::F64(123.456))],
+            },
+        ];
+        let record = Record {
+            ts: 1385053862.3072,
+            hostname: "example.org".to_string(),
+            facility: None,
+            severity: Some(1),
+            appname: Some("appname".to_string()),
+            procid: Some("44".to_string()),
+            msgid: None,
+            msg: Some("A short message that helps you identify what is going on".to_string()),
+            full_msg: Some("Backtrace here\n\nmore stuff".to_string()),
+            sd: Some(sd_vec),
+        };
+
+        assert_eq!(
+            String::from_utf8_lossy(&encoder.encode(record).unwrap()),
+            "\u{0}\u{0}\u{0}\u{0}%\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{2}\u{0}\t\u{0}*������A�\u{1}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}!\u{0}\u{0}\u{0}b\u{0}\u{0}\u{0}%\u{0}\u{0}\u{0}B\u{0}\u{0}\u{0}%\u{0}\u{0}\u{0}\u{1a}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}!\u{0}\u{0}\u{0}�\u{1}\u{0}\u{0}=\u{0}\u{0}\u{0}�\u{0}\u{0}\u{0}I\u{0}\u{0}\u{0}:\u{0}\u{0}\u{0}I\u{0}\u{0}\u{0}\'\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}example.org\u{0}\u{0}\u{0}\u{0}\u{0}appname\u{0}44\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}A short message that helps you identify what is going on\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}Backtrace here\n\nmore stuff\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}someid\u{0}\u{0}\u{4}\u{0}\u{0}\u{0}\u{2}\u{0}\u{2}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{5}\u{0}\u{0}\u{0}Z\u{0}\u{0}\u{0}\t\u{0}\u{0}\u{0}\"\u{0}\u{0}\u{0}_some_info\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}foo\u{0}\u{0}\u{0}\u{0}\u{0}"
         );
     }
 }

--- a/src/flowgger/encoder/gelf_encoder.rs
+++ b/src/flowgger/encoder/gelf_encoder.rs
@@ -84,20 +84,27 @@ impl Encoder for GelfEncoder {
         if let Some(procid) = record.procid {
             map = map.insert("process_id".to_owned(), Value::String(procid));
         }
-        if let Some(sd) = record.sd {
-            if let Some(sd_id) = sd.sd_id {
-                map = map.insert("sd_id".to_owned(), Value::String(sd_id));
-            }
-            for (name, value) in sd.pairs {
-                let value = match value {
-                    SDValue::String(value) => Value::String(value),
-                    SDValue::Bool(value) => Value::Bool(value),
-                    SDValue::F64(value) => Value::F64(value),
-                    SDValue::I64(value) => Value::I64(value),
-                    SDValue::U64(value) => Value::U64(value),
-                    SDValue::Null => Value::Null,
-                };
-                map = map.insert(name, value);
+        if let Some(sd_vec) = record.sd {
+            for &ref sd in &sd_vec {
+                // Warning: Gelf doesn't have a concept of structued data. In case there are
+                // several, all their attributes will be aded as fields. So if several structured
+                // data have the same key, only the last value will show as it will overwrite the
+                // others. We could use the sd_id to prefix the field to sove this but this is a
+                // breaking change.
+                if let Some(sd_id) = &sd.sd_id {
+                    map = map.insert("sd_id".to_owned(), Value::String(sd_id.to_string()));
+                }
+                for (name, value) in &sd.pairs {
+                    let value = match value {
+                        SDValue::String(value) => Value::String(value.to_string()),
+                        SDValue::Bool(value) => Value::Bool(*value),
+                        SDValue::F64(value) => Value::F64(*value),
+                        SDValue::I64(value) => Value::I64(*value),
+                        SDValue::U64(value) => Value::U64(*value),
+                        SDValue::Null => Value::Null,
+                    };
+                    map = map.insert(name, value);
+                }
             }
         }
         for (name, value) in self.extra.iter().cloned() {
@@ -131,7 +138,7 @@ mod tests {
             msgid: None,
             msg: Some("A short message that helps you identify what is going on".to_string()),
             full_msg: Some("Backtrace here\n\nmore stuff".to_string()),
-            sd: Some(sd),
+            sd: Some(vec![sd]),
         };
         let encoder = GelfEncoder::new(&config);
         assert_eq!(
@@ -180,7 +187,7 @@ mod tests {
             msgid: None,
             msg: Some("A short message that helps you identify what is going on".to_string()),
             full_msg: None,
-            sd: Some(sd),
+            sd: Some(vec![sd]),
         };
         let encoder = GelfEncoder::new(&config);
         assert_eq!(
@@ -201,5 +208,38 @@ mod tests {
     fn test_gelf_encoder_config_extra_bad_type() {
         let _encoder =
             GelfEncoder::new(&Config::from_string("[output.gelf_extra]\n_some_info = 42").unwrap());
+    }
+
+    #[test]
+    fn test_gelf_encode_multiple_sd() {
+        let expected_msg = r#"{"_some_info":"foo","application_name":"appname","full_message":"Backtrace here\n\nmore stuff","host":"example.org","info":123.456,"level":1,"process_id":"44","sd_id":"someid2","secret-token":"secret","short_message":"A short message that helps you identify what is going on","timestamp":1385053862.3072,"version":"1.1"}"#;
+        let config = Config::from_string("[output.gelf_extra]\nsecret-token = \"secret\"").unwrap();
+        let sd_vec = vec![
+            StructuredData {
+                sd_id: Some("someid".to_string()),
+                pairs: vec![("_some_info".to_string(), SDValue::String("foo".to_string()))],
+            },
+            StructuredData {
+                sd_id: Some("someid2".to_string()),
+                pairs: vec![("info".to_string(), SDValue::F64(123.456))],
+            },
+        ];
+        let record = Record {
+            ts: 1385053862.3072,
+            hostname: "example.org".to_string(),
+            facility: None,
+            severity: Some(1),
+            appname: Some("appname".to_string()),
+            procid: Some("44".to_string()),
+            msgid: None,
+            msg: Some("A short message that helps you identify what is going on".to_string()),
+            full_msg: Some("Backtrace here\n\nmore stuff".to_string()),
+            sd: Some(sd_vec),
+        };
+        let encoder = GelfEncoder::new(&config);
+        assert_eq!(
+            String::from_utf8_lossy(&encoder.encode(record).unwrap()),
+            expected_msg
+        );
     }
 }

--- a/src/flowgger/encoder/passthrough_encoder.rs
+++ b/src/flowgger/encoder/passthrough_encoder.rs
@@ -18,7 +18,7 @@ impl Encoder for PassthroughEncoder {
     /// Implementation of a passthrough encoder.
     /// Just pass the full raw messages from input without rebuilding them.
     /// This allows passing several different formats, i.e. rfc3164 can accept different formats.
-    /// The actual output format is therefore the format set set as input.
+    /// The actual output format is therefore the format set as input.
     fn encode(&self, record: Record) -> Result<Vec<u8>, &'static str> {
         let mut res = String::new();
 

--- a/src/flowgger/mod.rs
+++ b/src/flowgger/mod.rs
@@ -71,7 +71,6 @@ use self::output::KafkaOutput;
 #[cfg(feature = "tls")]
 use self::output::TlsOutput;
 use self::output::{DebugOutput, Output};
-use std::error::Error;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 
@@ -315,7 +314,7 @@ pub fn start(config_file: &str) {
         Err(e) => panic!(
             "Unable to read the config file [{}]: {}",
             config_file,
-            e.description()
+            e.to_string()
         ),
     };
     let input_format = config

--- a/src/flowgger/record.rs
+++ b/src/flowgger/record.rs
@@ -78,7 +78,7 @@ pub struct Record {
     pub msgid: Option<String>,
     pub msg: Option<String>,
     pub full_msg: Option<String>,
-    pub sd: Option<StructuredData>,
+    pub sd: Option<Vec<StructuredData>>,
 }
 
 #[cfg(feature = "capnp-recompile")]

--- a/src/flowgger/splitter/capnp_splitter.rs
+++ b/src/flowgger/splitter/capnp_splitter.rs
@@ -112,7 +112,7 @@ fn get_pairs(
     pairs
 }
 
-fn get_sd(message: record_capnp::record::Reader) -> Result<Option<StructuredData>, &'static str> {
+fn get_sd(message: record_capnp::record::Reader) -> Result<Option<Vec<StructuredData>>, &'static str> {
     let sd_id = message.get_sd_id().and_then(|x| Ok(x.to_owned())).ok();
     let pairs = message.get_pairs().ok();
     let extra = message.get_extra().ok();
@@ -124,7 +124,7 @@ fn get_sd(message: record_capnp::record::Reader) -> Result<Option<StructuredData
     } else {
         get_pairs(pairs, extra)
     };
-    Ok(Some(StructuredData { sd_id, pairs }))
+    Ok(Some(vec![StructuredData { sd_id, pairs }]))
 }
 
 fn handle_message(message: record_capnp::record::Reader) -> Result<Record, &'static str> {
@@ -184,7 +184,7 @@ mod tests {
             msgid: Some("".to_string()),
             msg: Some("A short message that helps you identify what is going on".to_string()),
             full_msg: Some("Backtrace here\n\nmore stuff".to_string()),
-            sd: Some(sd),
+            sd: Some(vec![sd]),
         };
 
         let capnp_message = vec![
@@ -218,6 +218,6 @@ mod tests {
         assert_eq!(record.msgid, expected.msgid);
         assert_eq!(record.msg, expected.msg);
         assert_eq!(record.full_msg, expected.full_msg);
-        assert_eq!(record.sd.unwrap().sd_id, expected.sd.unwrap().sd_id);
+        assert_eq!(record.sd.unwrap()[0].sd_id, expected.sd.unwrap()[0].sd_id);
     }
 }


### PR DESCRIPTION
*Issue #61 *

*Description of changes:*
- The log record structure has been updated to have structured data (SD) field as a vector instead of a single instance, in order to be able to hold multiple structured data
- Every decoder has been updated to store a vector with the processed SD (but only RFC5424 logs can have more than 1)
- RFC5424 decoder has been updated to parse every SD, in case multiple are specified, instead of only the first one
- Every encoder has beem updated to output every SD entry, whenever possible (capnp records can only hold 1, gelf and lstsv have limitation when the same key is specified in mutiple SD).
- Unit tests added for every encoder/decoder to validate the multiple SD handling
- Small typos and cosmetic changes
- Version update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
