### PR TITLE
Fix travis ci issue with drop of ssl support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ branches:
     # release tags
     - /^\d+\.\d+\.\d+.*$/
     - master
+    - /^bug\/.*/
+    - \^feature\/.*
 
 notifications:
   email:

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -13,19 +13,10 @@ main() {
         sort=gsort  # for `sort --sort-version`, from brew's coreutils.
     fi
 
-    # This fetches latest stable release
-    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
-                       | cut -d/ -f3 \
-                       | grep -E '^v[0-9.]+$' \
-                       | $sort --version-sort \
-                       | tail -n1)
-    echo cross version: $tag
-    curl -LSfs https://japaric.github.io/trust/install.sh | \
-        sh -s -- \
-           --force \
-           --git japaric/cross \
-           --tag $tag \
-           --target $target
+    # Cross removed support of openssl, which breaks in musl. We're using an older version.
+    # Eventually we may want to create a specific docker file for cross as mentionned here
+    # https://github.com/rust-embedded/cross/issues/229
+    cargo install --version 0.1.16 cross --force
 }
 
 main


### PR DESCRIPTION
Travis CI has been brokenf or a while.

Turns out [cross](https://github.com/rust-embedded/cross) stopped supporting the ssl library.
This cr updated and simplifies the cross tool installation, forcing using the version prior to ssl removal.
Eventually we may want to create a specific docker file using the latest cross version [as mentionned here](https://github.com/rust-embedded/cross/issues/229)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
