### PR TITLE
Run cargo fmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "flowgger"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["Frank Denis <github@pureftpd.org>", "Matteo Bigoi <bigo@crisidev.org>", "Vivien Chene <viv.chene@gmail.com>", "Francesco Berni <kurojishi@kurojishi.me>"]
 build = "build.rs"
 repository = "https://github.com/awslabs/flowgger"

--- a/src/flowgger/decoder/gelf_decoder.rs
+++ b/src/flowgger/decoder/gelf_decoder.rs
@@ -113,7 +113,11 @@ impl Decoder for GelfDecoder {
             appname: None,
             procid: None,
             msgid: None,
-            sd: if sd.pairs.is_empty() { None } else { Some(vec![sd]) },
+            sd: if sd.pairs.is_empty() {
+                None
+            } else {
+                Some(vec![sd])
+            },
             msg,
             full_msg,
         };

--- a/src/flowgger/decoder/ltsv_decoder.rs
+++ b/src/flowgger/decoder/ltsv_decoder.rs
@@ -40,10 +40,7 @@ impl LTSVDecoder {
                         "f64" => SDValueType::F64,
                         "i64" => SDValueType::I64,
                         "u64" => SDValueType::U64,
-                        _ => panic!(
-                            "Unsupported type in input.ltsv_schema for name [{}]",
-                            name
-                        ),
+                        _ => panic!("Unsupported type in input.ltsv_schema for name [{}]", name),
                     };
                     schema.insert(name.to_owned(), sdtype);
                 }
@@ -211,7 +208,11 @@ impl Decoder for LTSVDecoder {
             appname: None,
             procid: None,
             msgid: None,
-            sd: if sd.pairs.is_empty() { None } else { Some(vec![sd]) },
+            sd: if sd.pairs.is_empty() {
+                None
+            } else {
+                Some(vec![sd])
+            },
             msg,
             full_msg: Some(line.to_owned()),
         };

--- a/src/flowgger/decoder/rfc3164_decoder.rs
+++ b/src/flowgger/decoder/rfc3164_decoder.rs
@@ -32,13 +32,13 @@ impl Decoder for RFC3164Decoder {
         let (pri, _msg) = parse_strip_pri(line)?;
 
         let mut res = decode_rfc_standard(&pri, _msg, line);
-        if let Ok (record) = res  {
+        if let Ok(record) = res {
             return Ok(record);
         }
 
         // Specific implementation
         res = decode_rfc_custom(&pri, _msg, line);
-        if let Ok (record) = res  {
+        if let Ok(record) = res {
             return Ok(record);
         }
 
@@ -158,7 +158,10 @@ fn parse_date_token<'a>(ts_tokens: &'a [&str]) -> Result<(f64, Vec<&'a str>), &'
     parse_date(ts_tokens, false).or_else(|_| parse_date(ts_tokens, true))
 }
 
-fn parse_date<'a>(ts_tokens: &'a [&str], has_year: bool) -> Result<(f64, Vec<&'a str>), &'static str> {
+fn parse_date<'a>(
+    ts_tokens: &'a [&str],
+    has_year: bool,
+) -> Result<(f64, Vec<&'a str>), &'static str> {
     // Decode the date/time from the given tokens with optional year specified
     let ts_str;
     let mut idx;
@@ -167,8 +170,7 @@ fn parse_date<'a>(ts_tokens: &'a [&str], has_year: bool) -> Result<(f64, Vec<&'a
     if has_year {
         idx = 4;
         ts_str = ts_tokens[0..idx].join(" ");
-    }
-    else {
+    } else {
         idx = 3;
         let current_year = Utc::now().year();
         ts_str = format!("{} {}", current_year, ts_tokens[0..idx].join(" "));
@@ -178,7 +180,11 @@ fn parse_date<'a>(ts_tokens: &'a [&str], has_year: bool) -> Result<(f64, Vec<&'a
         Ok(naive_dt) => {
             // See if the next token is a timezone
             let mut ts = 0.0;
-            let tz_res: Result<Tz, String> = if ts_tokens.len() > idx { ts_tokens[idx].parse() } else { Err("No timezone".to_string()) };
+            let tz_res: Result<Tz, String> = if ts_tokens.len() > idx {
+                ts_tokens[idx].parse()
+            } else {
+                Err("No timezone".to_string())
+            };
             if let Ok(tz) = tz_res {
                 let dt = tz.from_local_datetime(&naive_dt).single();
                 if dt.is_some() {
@@ -191,15 +197,15 @@ fn parse_date<'a>(ts_tokens: &'a [&str], has_year: bool) -> Result<(f64, Vec<&'a
                 ts = utils::PreciseTimestamp::from_naive_datetime(naive_dt).as_f64();
             }
             Ok((ts, ts_tokens[idx..].to_vec()))
-        },
-        Err(_err) => {
-            Err("Unable to parse date")
         }
+        Err(_err) => Err("Unable to parse date"),
     }
 }
 
 #[cfg(test)]
-use crate::flowgger::utils::test_utils::rfc_test_utils::{ts_from_partial_date_time, ts_from_date_time};
+use crate::flowgger::utils::test_utils::rfc_test_utils::{
+    ts_from_date_time, ts_from_partial_date_time,
+};
 
 #[test]
 fn test_rfc3164_decode_nopri() {
@@ -338,7 +344,10 @@ fn test_rfc3164_decode_custom_with_year() {
     assert_eq!(res.appname, None);
     assert_eq!(res.procid, None);
     assert_eq!(res.msgid, None);
-    assert_eq!(res.msg, Some(r#"appname 69 42 some test message"#.to_string()));
+    assert_eq!(
+        res.msg,
+        Some(r#"appname 69 42 some test message"#.to_string())
+    );
     assert_eq!(res.full_msg, Some(msg.to_string()));
     assert!(res.sd.is_none());
 }
@@ -398,6 +407,9 @@ fn test_rfc3164_decode_custom_trimed() {
     assert_eq!(res.appname, None);
     assert_eq!(res.procid, None);
     assert_eq!(res.msgid, None);
-    assert_eq!(res.full_msg, Some("<13>testhostname: 2019 Mar 27 12:09:39 UTC: appname: test message".to_string()));
+    assert_eq!(
+        res.full_msg,
+        Some("<13>testhostname: 2019 Mar 27 12:09:39 UTC: appname: test message".to_string())
+    );
     assert!(res.sd.is_none());
 }

--- a/src/flowgger/decoder/rfc5424_decoder.rs
+++ b/src/flowgger/decoder/rfc5424_decoder.rs
@@ -36,7 +36,11 @@ impl Decoder for RFC5424Decoder {
             appname: Some(appname.to_owned()),
             procid: Some(procid.to_owned()),
             msgid: Some(msgid.to_owned()),
-            sd: if sd_vec.is_empty() { None } else { Some(sd_vec) },
+            sd: if sd_vec.is_empty() {
+                None
+            } else {
+                Some(sd_vec)
+            },
             msg,
             full_msg: Some(line.trim_end().to_owned()),
         };
@@ -120,7 +124,7 @@ fn unescape_sd_value(value: &str) -> String {
 }
 
 fn parse_data(line: &str) -> Result<(Vec<StructuredData>, Option<String>), &'static str> {
-    let mut sd_vec:Vec<StructuredData> = Vec::new();
+    let mut sd_vec: Vec<StructuredData> = Vec::new();
     match line.chars().next().ok_or("Missing log message")? {
         '-' => {
             // No SD, just a message
@@ -137,7 +141,11 @@ fn parse_data(line: &str) -> Result<(Vec<StructuredData>, Option<String>), &'sta
                 offset = new_offset;
                 sd_vec.push(sd);
 
-                match leftover[offset..].chars().next().ok_or("Missing log message")? {
+                match leftover[offset..]
+                    .chars()
+                    .next()
+                    .ok_or("Missing log message")?
+                {
                     // Another SD
                     '[' => next_sd = true,
                     // Separator, the rest is the message

--- a/src/flowgger/encoder/ltsv_encoder.rs
+++ b/src/flowgger/encoder/ltsv_encoder.rs
@@ -132,7 +132,7 @@ use crate::flowgger::utils::test_utils::rfc_test_utils::ts_from_partial_date_tim
 #[test]
 fn test_ltsv_full_encode_no_sd() {
     let full_msg = "<23>Aug  6 11:15:24 testhostname appname[69]: 42 - some test message";
-    let expected_msg = "host:testhostname\ttime:1628248524\tmessage:some test message\tfull_message:<23>Aug  6 11:15:24 testhostname appname[69]: 42 - some test message\tlevel:7\tfacility:2\tappname:appname\tprocid:69\tmsgid:42";
+    let expected_msg = "host:testhostname\ttime:1659784524\tmessage:some test message\tfull_message:<23>Aug  6 11:15:24 testhostname appname[69]: 42 - some test message\tlevel:7\tfacility:2\tappname:appname\tprocid:69\tmsgid:42";
     let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"ltsv\"\n").unwrap();
     let ts = ts_from_partial_date_time(8, 6, 11, 15, 24);
 
@@ -154,11 +154,10 @@ fn test_ltsv_full_encode_no_sd() {
     assert_eq!(String::from_utf8_lossy(&res), expected_msg);
 }
 
-
 #[test]
 fn test_ltsv_full_encode_multiple_sd() {
     let full_msg = "<23>Aug  6 11:15:24 testhostname appname[69]: 42 [someid a=\"b\" c=\"123456\"][someid2 a2=\"b2\" c2=\"123456\"] some test message";
-    let expected_msg = "a:b\tc:123456\ta2:b2\tc2:123456\thost:testhostname\ttime:1628248524\tmessage:some test message\tfull_message:<23>Aug  6 11:15:24 testhostname appname[69]: 42 [someid a=\"b\" c=\"123456\"][someid2 a2=\"b2\" c2=\"123456\"] some test message\tlevel:7\tfacility:2\tappname:appname\tprocid:69\tmsgid:42";
+    let expected_msg = "a:b\tc:123456\ta2:b2\tc2:123456\thost:testhostname\ttime:1659784524\tmessage:some test message\tfull_message:<23>Aug  6 11:15:24 testhostname appname[69]: 42 [someid a=\"b\" c=\"123456\"][someid2 a2=\"b2\" c2=\"123456\"] some test message\tlevel:7\tfacility:2\tappname:appname\tprocid:69\tmsgid:42";
     let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"ltsv\"\n").unwrap();
     let ts = ts_from_partial_date_time(8, 6, 11, 15, 24);
 

--- a/src/flowgger/encoder/mod.rs
+++ b/src/flowgger/encoder/mod.rs
@@ -4,12 +4,12 @@ mod capnp_encoder;
 mod gelf_encoder;
 #[cfg(feature = "ltsv")]
 mod ltsv_encoder;
+#[cfg(feature = "passthrough")]
+mod passthrough_encoder;
 #[cfg(feature = "rfc3164")]
 mod rfc3164_encoder;
 #[cfg(feature = "rfc5424")]
 mod rfc5424_encoder;
-#[cfg(feature = "passthrough")]
-mod passthrough_encoder;
 
 #[cfg(feature = "capnp-recompile")]
 pub use self::capnp_encoder::CapnpEncoder;
@@ -17,16 +17,16 @@ pub use self::capnp_encoder::CapnpEncoder;
 pub use self::gelf_encoder::GelfEncoder;
 #[cfg(feature = "ltsv")]
 pub use self::ltsv_encoder::LTSVEncoder;
+#[cfg(feature = "passthrough")]
+pub use self::passthrough_encoder::PassthroughEncoder;
 #[cfg(feature = "rfc3164")]
 pub use self::rfc3164_encoder::RFC3164Encoder;
 #[cfg(feature = "rfc5424")]
 pub use self::rfc5424_encoder::RFC5424Encoder;
-#[cfg(feature = "passthrough")]
-pub use self::passthrough_encoder::PassthroughEncoder;
 
+use crate::flowgger::config::Config;
 use crate::flowgger::record::Record;
 use chrono::Utc;
-use crate::flowgger::config::Config;
 
 pub trait CloneBoxedEncoder {
     fn clone_boxed<'a>(&self) -> Box<dyn Encoder + Send + 'a>
@@ -57,14 +57,16 @@ pub fn config_get_prepend_ts(config: &Config) -> Option<String> {
     config
         .lookup("output.syslog_prepend_timestamp")
         .map_or(None, |bs| {
-            Some(bs.as_str()
-                .expect("output.syslog_prepend_timestamp should be a string")
-                .to_string())
+            Some(
+                bs.as_str()
+                    .expect("output.syslog_prepend_timestamp should be a string")
+                    .to_string(),
+            )
         })
 }
 
 pub fn build_prepend_ts(format_str: &str) -> String {
-    let current_time  = Utc::now();
+    let current_time = Utc::now();
     // let format_str: &str = format.as_ref().unwrap();
     current_time.format(format_str).to_string()
 }

--- a/src/flowgger/encoder/passthrough_encoder.rs
+++ b/src/flowgger/encoder/passthrough_encoder.rs
@@ -1,4 +1,4 @@
-use super::{Encoder, config_get_prepend_ts, build_prepend_ts};
+use super::{build_prepend_ts, config_get_prepend_ts, Encoder};
 use crate::flowgger::config::Config;
 use crate::flowgger::record::Record;
 
@@ -32,8 +32,7 @@ impl Encoder for PassthroughEncoder {
             // Pysh the message
             res.push_str(&msg);
             Ok(res.into_bytes())
-        }
-        else {
+        } else {
             Err("Cannot output empty raw message")
         }
     }
@@ -45,10 +44,11 @@ use chrono::Utc;
 #[test]
 fn test_passthrough_encode() {
     let expected_msg = r#"Aug  6 11:15:24 testhostname appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#;
-    let cfg = Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"passthrough\"\n").unwrap();
+    let cfg =
+        Config::from_string("[input]\n[input.ltsv_schema]\nformat = \"passthrough\"\n").unwrap();
 
     let record = Record {
-        ts:1.2,
+        ts: 1.2,
         hostname: "abcd".to_string(),
         facility: None,
         severity: None,
@@ -67,10 +67,16 @@ fn test_passthrough_encode() {
 
 #[test]
 fn test_passthrough_encode_with_prepend() {
-    let cfg = Config::from_string("[output]\nformat = \"passthrough\"\nsyslog_prepend_timestamp=\"[%Y-%m-%dT%H:%MZ]\"").unwrap();
+    let cfg = Config::from_string(
+        "[output]\nformat = \"passthrough\"\nsyslog_prepend_timestamp=\"[%Y-%m-%dT%H:%MZ]\"",
+    )
+    .unwrap();
     let dt = Utc::now();
     let dt_str = dt.format("[%Y-%m-%dT%H:%MZ]").to_string();
-    let input_msg = format!(r#"{}Aug  6 11:15:24 testhostname appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#, dt_str);
+    let input_msg = format!(
+        r#"{}Aug  6 11:15:24 testhostname appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#,
+        dt_str
+    );
     let expected_msg = format!(r#"{}{}"#, dt_str, input_msg);
 
     let record = Record {
@@ -94,14 +100,19 @@ fn test_passthrough_encode_with_prepend() {
 #[test]
 #[should_panic(expected = "output.syslog_prepend_timestamp should be a string")]
 fn test_passthrough_encode_invalid_prepend() {
-    let cfg = Config::from_string("[output]\nformat = \"passthrough\"\nsyslog_prepend_timestamp=123").unwrap();
+    let cfg =
+        Config::from_string("[output]\nformat = \"passthrough\"\nsyslog_prepend_timestamp=123")
+            .unwrap();
     let _ = PassthroughEncoder::new(&cfg);
 }
 
 #[test]
 #[should_panic(expected = "Cannot output empty raw message")]
 fn test_passthrough_encode_no_msg() {
-    let cfg = Config::from_string("[output]\nformat = \"passthrough\"\nsyslog_prepend_timestamp=\"[%Y-%m-%dT%H:%MZ]\"").unwrap();
+    let cfg = Config::from_string(
+        "[output]\nformat = \"passthrough\"\nsyslog_prepend_timestamp=\"[%Y-%m-%dT%H:%MZ]\"",
+    )
+    .unwrap();
 
     let record = Record {
         ts: 1.2,

--- a/src/flowgger/encoder/rfc3164_encoder.rs
+++ b/src/flowgger/encoder/rfc3164_encoder.rs
@@ -1,4 +1,4 @@
-use super::{Encoder, config_get_prepend_ts, build_prepend_ts};
+use super::{build_prepend_ts, config_get_prepend_ts, Encoder};
 use crate::flowgger::config::Config;
 use crate::flowgger::record::Record;
 use chrono::NaiveDateTime;
@@ -135,12 +135,17 @@ fn test_rfc3164_withpri_encode() {
 
 #[test]
 fn test_rfc3164_encode_with_prepend() {
-    let cfg = Config::from_string("[output]\nformat = \"rfc3164\"\nsyslog_prepend_timestamp=\"[%Y-%m-%dT%H:%MZ]\"").unwrap();
+    let cfg = Config::from_string(
+        "[output]\nformat = \"rfc3164\"\nsyslog_prepend_timestamp=\"[%Y-%m-%dT%H:%MZ]\"",
+    )
+    .unwrap();
     let ts = ts_from_partial_date_time(8, 6, 11, 15, 24);
     let dt = Utc::now();
     let dt_str = dt.format("[%Y-%m-%dT%H:%MZ]").to_string();
-    let expected_msg = format!(r#"{}Aug  6 11:15:24 testhostname appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#, dt_str);
-
+    let expected_msg = format!(
+        r#"{}Aug  6 11:15:24 testhostname appname 69 42 [origin@123 software="te\st sc\"ript" swVersion="0.0.1"] test message"#,
+        dt_str
+    );
 
     let record = Record {
         ts,
@@ -163,7 +168,8 @@ fn test_rfc3164_encode_with_prepend() {
 #[test]
 #[should_panic(expected = "output.syslog_prepend_timestamp should be a string")]
 fn test_rfc3164_invalid_prepend() {
-    let cfg = Config::from_string("[output]\nformat = \"rfc3164\"\nsyslog_prepend_timestamp=123").unwrap();
+    let cfg = Config::from_string("[output]\nformat = \"rfc3164\"\nsyslog_prepend_timestamp=123")
+        .unwrap();
     let _ = RFC3164Encoder::new(&cfg);
 }
 

--- a/src/flowgger/encoder/rfc5424_encoder.rs
+++ b/src/flowgger/encoder/rfc5424_encoder.rs
@@ -186,16 +186,10 @@ fn test_rfc5424_full_encode_multiple_sd() {
             StructuredData {
                 sd_id: Some("master@456".to_string()),
                 pairs: vec![
-                    (
-                        "key1".to_string(),
-                        SDValue::String(r#"value1"#.to_string()),
-                    ),
-                    (
-                        "key2".to_string(),
-                        SDValue::String("value2".to_string()),
-                    ),
+                    ("key1".to_string(), SDValue::String(r#"value1"#.to_string())),
+                    ("key2".to_string(), SDValue::String("value2".to_string())),
                 ],
-            }
+            },
         ]),
     };
 

--- a/src/flowgger/mod.rs
+++ b/src/flowgger/mod.rs
@@ -46,12 +46,12 @@ use self::encoder::Encoder;
 use self::encoder::GelfEncoder;
 #[cfg(feature = "ltsv")]
 use self::encoder::LTSVEncoder;
+#[cfg(feature = "passthrough")]
+use self::encoder::PassthroughEncoder;
 #[cfg(feature = "rfc3164")]
 use self::encoder::RFC3164Encoder;
 #[cfg(feature = "rfc5424")]
 use self::encoder::RFC5424Encoder;
-#[cfg(feature = "passthrough")]
-use self::encoder::PassthroughEncoder;
 #[cfg(feature = "file")]
 use self::input::FileInput;
 #[cfg(feature = "redis-input")]

--- a/src/flowgger/output/file_output.rs
+++ b/src/flowgger/output/file_output.rs
@@ -580,5 +580,4 @@ mod tests {
         test_object.setup_nowriter(cfg);
         Ok(())
     }
-
 }

--- a/src/flowgger/splitter/capnp_splitter.rs
+++ b/src/flowgger/splitter/capnp_splitter.rs
@@ -112,7 +112,9 @@ fn get_pairs(
     pairs
 }
 
-fn get_sd(message: record_capnp::record::Reader) -> Result<Option<Vec<StructuredData>>, &'static str> {
+fn get_sd(
+    message: record_capnp::record::Reader,
+) -> Result<Option<Vec<StructuredData>>, &'static str> {
     let sd_id = message.get_sd_id().and_then(|x| Ok(x.to_owned())).ok();
     let pairs = message.get_pairs().ok();
     let extra = message.get_extra().ok();

--- a/src/flowgger/utils/test_utils.rs
+++ b/src/flowgger/utils/test_utils.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 pub mod rfc_test_utils {
     use crate::flowgger::utils;
-    use chrono::{Datelike, NaiveDateTime, Utc, DateTime};
+    use chrono::{DateTime, Datelike, NaiveDateTime, Utc};
 
     /// Converts a partial date to a timestamp in ms assuming the year is the current one
     #[inline]
@@ -18,7 +18,7 @@ pub mod rfc_test_utils {
         min: u32,
         sec: u32,
         msec: u32,
-    )  -> NaiveDateTime {
+    ) -> NaiveDateTime {
         // Compute the timestamp we expect
         let d = chrono::NaiveDate::from_ymd(year, month, day);
         let t = chrono::NaiveTime::from_hms_milli(hour, min, sec, msec);
@@ -52,6 +52,5 @@ pub mod rfc_test_utils {
         let dt = new_date_time(year, month, day, hour, min, sec, msec);
         DateTime::from_utc(dt, Utc)
     }
-//
-
+    //
 }

--- a/src/record_capnp.rs
+++ b/src/record_capnp.rs
@@ -2,745 +2,944 @@
 // DO NOT EDIT.
 // source: record.capnp
 
-
 pub mod record {
-  #[derive(Copy, Clone)]
-  pub struct Owned;
-  impl <'a> ::capnp::traits::Owned<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
-  impl <'a> ::capnp::traits::OwnedStruct<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-  #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-    #[inline]
-    fn type_id() -> u64 { _private::TYPE_ID }
-  }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
-      Reader { reader: reader,  }
+    #[derive(Copy, Clone)]
+    pub struct Owned;
+    impl<'a> ::capnp::traits::Owned<'a> for Owned {
+        type Reader = Reader<'a>;
+        type Builder = Builder<'a>;
     }
-  }
-
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::std::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::std::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
+    impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
+        type Reader = Reader<'a>;
+        type Builder = Builder<'a>;
     }
-  }
-
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-      self.reader
-    }
-  }
-
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-    }
-  }
-
-  impl <'a,> Reader<'a,>  {
-    pub fn reborrow(&self) -> Reader<> {
-      Reader { .. *self }
+    impl ::capnp::traits::Pipelined for Owned {
+        type Pipeline = Pipeline;
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.reader.total_size()
-    }
-    #[inline]
-    pub fn get_ts(self) -> f64 {
-      self.reader.get_data_field::<f64>(0)
-    }
-    #[inline]
-    pub fn get_hostname(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::std::option::Option::None)
-    }
-    pub fn has_hostname(&self) -> bool {
-      !self.reader.get_pointer_field(0).is_null()
-    }
-    #[inline]
-    pub fn get_facility(self) -> u8 {
-      self.reader.get_data_field::<u8>(8)
-    }
-    #[inline]
-    pub fn get_severity(self) -> u8 {
-      self.reader.get_data_field::<u8>(9)
-    }
-    #[inline]
-    pub fn get_appname(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::std::option::Option::None)
-    }
-    pub fn has_appname(&self) -> bool {
-      !self.reader.get_pointer_field(1).is_null()
-    }
-    #[inline]
-    pub fn get_procid(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::std::option::Option::None)
-    }
-    pub fn has_procid(&self) -> bool {
-      !self.reader.get_pointer_field(2).is_null()
-    }
-    #[inline]
-    pub fn get_msgid(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(3), ::std::option::Option::None)
-    }
-    pub fn has_msgid(&self) -> bool {
-      !self.reader.get_pointer_field(3).is_null()
-    }
-    #[inline]
-    pub fn get_msg(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(4), ::std::option::Option::None)
-    }
-    pub fn has_msg(&self) -> bool {
-      !self.reader.get_pointer_field(4).is_null()
-    }
-    #[inline]
-    pub fn get_full_msg(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(5), ::std::option::Option::None)
-    }
-    pub fn has_full_msg(&self) -> bool {
-      !self.reader.get_pointer_field(5).is_null()
-    }
-    #[inline]
-    pub fn get_sd_id(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(6), ::std::option::Option::None)
-    }
-    pub fn has_sd_id(&self) -> bool {
-      !self.reader.get_pointer_field(6).is_null()
-    }
-    #[inline]
-    pub fn get_pairs(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::record_capnp::pair::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(7), ::std::option::Option::None)
-    }
-    pub fn has_pairs(&self) -> bool {
-      !self.reader.get_pointer_field(7).is_null()
-    }
-    #[inline]
-    pub fn get_extra(self) -> ::capnp::Result<::capnp::struct_list::Reader<'a,crate::record_capnp::pair::Owned>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(8), ::std::option::Option::None)
-    }
-    pub fn has_extra(&self) -> bool {
-      !self.reader.get_pointer_field(8).is_null()
-    }
-  }
-
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    #[inline]
-    fn struct_size() -> ::capnp::private::layout::StructSize { _private::STRUCT_SIZE }
-  }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-    #[inline]
-    fn type_id() -> u64 { _private::TYPE_ID }
-  }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
-      Builder { builder: builder,  }
-    }
-  }
-
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-    }
-  }
-
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
-    }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::std::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::std::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(_private::STRUCT_SIZE, default)?))
-    }
-  }
-
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-  }
-
-  impl <'a,> Builder<'a,>  {
-    pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
-    }
-    pub fn reborrow(&mut self) -> Builder<> {
-      Builder { .. *self }
-    }
-    pub fn reborrow_as_reader(&self) -> Reader<> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+    #[derive(Clone, Copy)]
+    pub struct Reader<'a> {
+        reader: ::capnp::private::layout::StructReader<'a>,
     }
 
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
+    impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+        #[inline]
+        fn type_id() -> u64 {
+            _private::TYPE_ID
+        }
     }
-    #[inline]
-    pub fn get_ts(self) -> f64 {
-      self.builder.get_data_field::<f64>(0)
+    impl<'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
+        fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
+            Reader { reader: reader }
+        }
     }
-    #[inline]
-    pub fn set_ts(&mut self, value: f64)  {
-      self.builder.set_data_field::<f64>(0, value);
-    }
-    #[inline]
-    pub fn get_hostname(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::std::option::Option::None)
-    }
-    #[inline]
-    pub fn set_hostname(&mut self, value: ::capnp::text::Reader)  {
-      self.builder.get_pointer_field(0).set_text(value);
-    }
-    #[inline]
-    pub fn init_hostname(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(0).init_text(size)
-    }
-    pub fn has_hostname(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
-    }
-    #[inline]
-    pub fn get_facility(self) -> u8 {
-      self.builder.get_data_field::<u8>(8)
-    }
-    #[inline]
-    pub fn set_facility(&mut self, value: u8)  {
-      self.builder.set_data_field::<u8>(8, value);
-    }
-    #[inline]
-    pub fn get_severity(self) -> u8 {
-      self.builder.get_data_field::<u8>(9)
-    }
-    #[inline]
-    pub fn set_severity(&mut self, value: u8)  {
-      self.builder.set_data_field::<u8>(9, value);
-    }
-    #[inline]
-    pub fn get_appname(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::std::option::Option::None)
-    }
-    #[inline]
-    pub fn set_appname(&mut self, value: ::capnp::text::Reader)  {
-      self.builder.get_pointer_field(1).set_text(value);
-    }
-    #[inline]
-    pub fn init_appname(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(1).init_text(size)
-    }
-    pub fn has_appname(&self) -> bool {
-      !self.builder.get_pointer_field(1).is_null()
-    }
-    #[inline]
-    pub fn get_procid(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::std::option::Option::None)
-    }
-    #[inline]
-    pub fn set_procid(&mut self, value: ::capnp::text::Reader)  {
-      self.builder.get_pointer_field(2).set_text(value);
-    }
-    #[inline]
-    pub fn init_procid(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(2).init_text(size)
-    }
-    pub fn has_procid(&self) -> bool {
-      !self.builder.get_pointer_field(2).is_null()
-    }
-    #[inline]
-    pub fn get_msgid(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(3), ::std::option::Option::None)
-    }
-    #[inline]
-    pub fn set_msgid(&mut self, value: ::capnp::text::Reader)  {
-      self.builder.get_pointer_field(3).set_text(value);
-    }
-    #[inline]
-    pub fn init_msgid(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(3).init_text(size)
-    }
-    pub fn has_msgid(&self) -> bool {
-      !self.builder.get_pointer_field(3).is_null()
-    }
-    #[inline]
-    pub fn get_msg(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(4), ::std::option::Option::None)
-    }
-    #[inline]
-    pub fn set_msg(&mut self, value: ::capnp::text::Reader)  {
-      self.builder.get_pointer_field(4).set_text(value);
-    }
-    #[inline]
-    pub fn init_msg(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(4).init_text(size)
-    }
-    pub fn has_msg(&self) -> bool {
-      !self.builder.get_pointer_field(4).is_null()
-    }
-    #[inline]
-    pub fn get_full_msg(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(5), ::std::option::Option::None)
-    }
-    #[inline]
-    pub fn set_full_msg(&mut self, value: ::capnp::text::Reader)  {
-      self.builder.get_pointer_field(5).set_text(value);
-    }
-    #[inline]
-    pub fn init_full_msg(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(5).init_text(size)
-    }
-    pub fn has_full_msg(&self) -> bool {
-      !self.builder.get_pointer_field(5).is_null()
-    }
-    #[inline]
-    pub fn get_sd_id(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(6), ::std::option::Option::None)
-    }
-    #[inline]
-    pub fn set_sd_id(&mut self, value: ::capnp::text::Reader)  {
-      self.builder.get_pointer_field(6).set_text(value);
-    }
-    #[inline]
-    pub fn init_sd_id(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(6).init_text(size)
-    }
-    pub fn has_sd_id(&self) -> bool {
-      !self.builder.get_pointer_field(6).is_null()
-    }
-    #[inline]
-    pub fn get_pairs(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::record_capnp::pair::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(7), ::std::option::Option::None)
-    }
-    #[inline]
-    pub fn set_pairs(&mut self, value: ::capnp::struct_list::Reader<'a,crate::record_capnp::pair::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(7), value, false)
-    }
-    #[inline]
-    pub fn init_pairs(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::record_capnp::pair::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(7), size)
-    }
-    pub fn has_pairs(&self) -> bool {
-      !self.builder.get_pointer_field(7).is_null()
-    }
-    #[inline]
-    pub fn get_extra(self) -> ::capnp::Result<::capnp::struct_list::Builder<'a,crate::record_capnp::pair::Owned>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(8), ::std::option::Option::None)
-    }
-    #[inline]
-    pub fn set_extra(&mut self, value: ::capnp::struct_list::Reader<'a,crate::record_capnp::pair::Owned>) -> ::capnp::Result<()> {
-      ::capnp::traits::SetPointerBuilder::set_pointer_builder(self.builder.get_pointer_field(8), value, false)
-    }
-    #[inline]
-    pub fn init_extra(self, size: u32) -> ::capnp::struct_list::Builder<'a,crate::record_capnp::pair::Owned> {
-      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(8), size)
-    }
-    pub fn has_extra(&self) -> bool {
-      !self.builder.get_pointer_field(8).is_null()
-    }
-  }
 
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
-      Pipeline { _typeless: typeless,  }
+    impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+        fn get_from_pointer(
+            reader: &::capnp::private::layout::PointerReader<'a>,
+            default: ::std::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Reader<'a>> {
+            ::std::result::Result::Ok(::capnp::traits::FromStructReader::new(
+                reader.get_struct(default)?,
+            ))
+        }
     }
-  }
-  impl Pipeline  {
-  }
-  mod _private {
-    use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 2, pointers: 9 };
-    pub const TYPE_ID: u64 = 0xe106_8a6a_ee02_baba;
-  }
+
+    impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+            self.reader
+        }
+    }
+
+    impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+            self.reader
+                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+        }
+    }
+
+    impl<'a> Reader<'a> {
+        pub fn reborrow(&self) -> Reader {
+            Reader { ..*self }
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.reader.total_size()
+        }
+        #[inline]
+        pub fn get_ts(self) -> f64 {
+            self.reader.get_data_field::<f64>(0)
+        }
+        #[inline]
+        pub fn get_hostname(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(0),
+                ::std::option::Option::None,
+            )
+        }
+        pub fn has_hostname(&self) -> bool {
+            !self.reader.get_pointer_field(0).is_null()
+        }
+        #[inline]
+        pub fn get_facility(self) -> u8 {
+            self.reader.get_data_field::<u8>(8)
+        }
+        #[inline]
+        pub fn get_severity(self) -> u8 {
+            self.reader.get_data_field::<u8>(9)
+        }
+        #[inline]
+        pub fn get_appname(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(1),
+                ::std::option::Option::None,
+            )
+        }
+        pub fn has_appname(&self) -> bool {
+            !self.reader.get_pointer_field(1).is_null()
+        }
+        #[inline]
+        pub fn get_procid(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(2),
+                ::std::option::Option::None,
+            )
+        }
+        pub fn has_procid(&self) -> bool {
+            !self.reader.get_pointer_field(2).is_null()
+        }
+        #[inline]
+        pub fn get_msgid(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(3),
+                ::std::option::Option::None,
+            )
+        }
+        pub fn has_msgid(&self) -> bool {
+            !self.reader.get_pointer_field(3).is_null()
+        }
+        #[inline]
+        pub fn get_msg(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(4),
+                ::std::option::Option::None,
+            )
+        }
+        pub fn has_msg(&self) -> bool {
+            !self.reader.get_pointer_field(4).is_null()
+        }
+        #[inline]
+        pub fn get_full_msg(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(5),
+                ::std::option::Option::None,
+            )
+        }
+        pub fn has_full_msg(&self) -> bool {
+            !self.reader.get_pointer_field(5).is_null()
+        }
+        #[inline]
+        pub fn get_sd_id(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(6),
+                ::std::option::Option::None,
+            )
+        }
+        pub fn has_sd_id(&self) -> bool {
+            !self.reader.get_pointer_field(6).is_null()
+        }
+        #[inline]
+        pub fn get_pairs(
+            self,
+        ) -> ::capnp::Result<::capnp::struct_list::Reader<'a, crate::record_capnp::pair::Owned>>
+        {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(7),
+                ::std::option::Option::None,
+            )
+        }
+        pub fn has_pairs(&self) -> bool {
+            !self.reader.get_pointer_field(7).is_null()
+        }
+        #[inline]
+        pub fn get_extra(
+            self,
+        ) -> ::capnp::Result<::capnp::struct_list::Reader<'a, crate::record_capnp::pair::Owned>>
+        {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(8),
+                ::std::option::Option::None,
+            )
+        }
+        pub fn has_extra(&self) -> bool {
+            !self.reader.get_pointer_field(8).is_null()
+        }
+    }
+
+    pub struct Builder<'a> {
+        builder: ::capnp::private::layout::StructBuilder<'a>,
+    }
+    impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+        #[inline]
+        fn struct_size() -> ::capnp::private::layout::StructSize {
+            _private::STRUCT_SIZE
+        }
+    }
+    impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+        #[inline]
+        fn type_id() -> u64 {
+            _private::TYPE_ID
+        }
+    }
+    impl<'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
+        fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
+            Builder { builder: builder }
+        }
+    }
+
+    impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+            self.builder
+                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+        }
+    }
+
+    impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+        fn init_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            _size: u32,
+        ) -> Builder<'a> {
+            ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+        }
+        fn get_from_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            default: ::std::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Builder<'a>> {
+            ::std::result::Result::Ok(::capnp::traits::FromStructBuilder::new(
+                builder.get_struct(_private::STRUCT_SIZE, default)?,
+            ))
+        }
+    }
+
+    impl<'a> ::capnp::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+        fn set_pointer_builder<'b>(
+            pointer: ::capnp::private::layout::PointerBuilder<'b>,
+            value: Reader<'a>,
+            canonicalize: bool,
+        ) -> ::capnp::Result<()> {
+            pointer.set_struct(&value.reader, canonicalize)
+        }
+    }
+
+    impl<'a> Builder<'a> {
+        pub fn into_reader(self) -> Reader<'a> {
+            ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        }
+        pub fn reborrow(&mut self) -> Builder {
+            Builder { ..*self }
+        }
+        pub fn reborrow_as_reader(&self) -> Reader {
+            ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.builder.into_reader().total_size()
+        }
+        #[inline]
+        pub fn get_ts(self) -> f64 {
+            self.builder.get_data_field::<f64>(0)
+        }
+        #[inline]
+        pub fn set_ts(&mut self, value: f64) {
+            self.builder.set_data_field::<f64>(0, value);
+        }
+        #[inline]
+        pub fn get_hostname(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(0),
+                ::std::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_hostname(&mut self, value: ::capnp::text::Reader) {
+            self.builder.get_pointer_field(0).set_text(value);
+        }
+        #[inline]
+        pub fn init_hostname(self, size: u32) -> ::capnp::text::Builder<'a> {
+            self.builder.get_pointer_field(0).init_text(size)
+        }
+        pub fn has_hostname(&self) -> bool {
+            !self.builder.get_pointer_field(0).is_null()
+        }
+        #[inline]
+        pub fn get_facility(self) -> u8 {
+            self.builder.get_data_field::<u8>(8)
+        }
+        #[inline]
+        pub fn set_facility(&mut self, value: u8) {
+            self.builder.set_data_field::<u8>(8, value);
+        }
+        #[inline]
+        pub fn get_severity(self) -> u8 {
+            self.builder.get_data_field::<u8>(9)
+        }
+        #[inline]
+        pub fn set_severity(&mut self, value: u8) {
+            self.builder.set_data_field::<u8>(9, value);
+        }
+        #[inline]
+        pub fn get_appname(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(1),
+                ::std::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_appname(&mut self, value: ::capnp::text::Reader) {
+            self.builder.get_pointer_field(1).set_text(value);
+        }
+        #[inline]
+        pub fn init_appname(self, size: u32) -> ::capnp::text::Builder<'a> {
+            self.builder.get_pointer_field(1).init_text(size)
+        }
+        pub fn has_appname(&self) -> bool {
+            !self.builder.get_pointer_field(1).is_null()
+        }
+        #[inline]
+        pub fn get_procid(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(2),
+                ::std::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_procid(&mut self, value: ::capnp::text::Reader) {
+            self.builder.get_pointer_field(2).set_text(value);
+        }
+        #[inline]
+        pub fn init_procid(self, size: u32) -> ::capnp::text::Builder<'a> {
+            self.builder.get_pointer_field(2).init_text(size)
+        }
+        pub fn has_procid(&self) -> bool {
+            !self.builder.get_pointer_field(2).is_null()
+        }
+        #[inline]
+        pub fn get_msgid(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(3),
+                ::std::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_msgid(&mut self, value: ::capnp::text::Reader) {
+            self.builder.get_pointer_field(3).set_text(value);
+        }
+        #[inline]
+        pub fn init_msgid(self, size: u32) -> ::capnp::text::Builder<'a> {
+            self.builder.get_pointer_field(3).init_text(size)
+        }
+        pub fn has_msgid(&self) -> bool {
+            !self.builder.get_pointer_field(3).is_null()
+        }
+        #[inline]
+        pub fn get_msg(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(4),
+                ::std::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_msg(&mut self, value: ::capnp::text::Reader) {
+            self.builder.get_pointer_field(4).set_text(value);
+        }
+        #[inline]
+        pub fn init_msg(self, size: u32) -> ::capnp::text::Builder<'a> {
+            self.builder.get_pointer_field(4).init_text(size)
+        }
+        pub fn has_msg(&self) -> bool {
+            !self.builder.get_pointer_field(4).is_null()
+        }
+        #[inline]
+        pub fn get_full_msg(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(5),
+                ::std::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_full_msg(&mut self, value: ::capnp::text::Reader) {
+            self.builder.get_pointer_field(5).set_text(value);
+        }
+        #[inline]
+        pub fn init_full_msg(self, size: u32) -> ::capnp::text::Builder<'a> {
+            self.builder.get_pointer_field(5).init_text(size)
+        }
+        pub fn has_full_msg(&self) -> bool {
+            !self.builder.get_pointer_field(5).is_null()
+        }
+        #[inline]
+        pub fn get_sd_id(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(6),
+                ::std::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_sd_id(&mut self, value: ::capnp::text::Reader) {
+            self.builder.get_pointer_field(6).set_text(value);
+        }
+        #[inline]
+        pub fn init_sd_id(self, size: u32) -> ::capnp::text::Builder<'a> {
+            self.builder.get_pointer_field(6).init_text(size)
+        }
+        pub fn has_sd_id(&self) -> bool {
+            !self.builder.get_pointer_field(6).is_null()
+        }
+        #[inline]
+        pub fn get_pairs(
+            self,
+        ) -> ::capnp::Result<::capnp::struct_list::Builder<'a, crate::record_capnp::pair::Owned>>
+        {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(7),
+                ::std::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_pairs(
+            &mut self,
+            value: ::capnp::struct_list::Reader<'a, crate::record_capnp::pair::Owned>,
+        ) -> ::capnp::Result<()> {
+            ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.get_pointer_field(7),
+                value,
+                false,
+            )
+        }
+        #[inline]
+        pub fn init_pairs(
+            self,
+            size: u32,
+        ) -> ::capnp::struct_list::Builder<'a, crate::record_capnp::pair::Owned> {
+            ::capnp::traits::FromPointerBuilder::init_pointer(
+                self.builder.get_pointer_field(7),
+                size,
+            )
+        }
+        pub fn has_pairs(&self) -> bool {
+            !self.builder.get_pointer_field(7).is_null()
+        }
+        #[inline]
+        pub fn get_extra(
+            self,
+        ) -> ::capnp::Result<::capnp::struct_list::Builder<'a, crate::record_capnp::pair::Owned>>
+        {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(8),
+                ::std::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_extra(
+            &mut self,
+            value: ::capnp::struct_list::Reader<'a, crate::record_capnp::pair::Owned>,
+        ) -> ::capnp::Result<()> {
+            ::capnp::traits::SetPointerBuilder::set_pointer_builder(
+                self.builder.get_pointer_field(8),
+                value,
+                false,
+            )
+        }
+        #[inline]
+        pub fn init_extra(
+            self,
+            size: u32,
+        ) -> ::capnp::struct_list::Builder<'a, crate::record_capnp::pair::Owned> {
+            ::capnp::traits::FromPointerBuilder::init_pointer(
+                self.builder.get_pointer_field(8),
+                size,
+            )
+        }
+        pub fn has_extra(&self) -> bool {
+            !self.builder.get_pointer_field(8).is_null()
+        }
+    }
+
+    pub struct Pipeline {
+        _typeless: ::capnp::any_pointer::Pipeline,
+    }
+    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+            Pipeline {
+                _typeless: typeless,
+            }
+        }
+    }
+    impl Pipeline {}
+    mod _private {
+        use capnp::private::layout;
+        pub const STRUCT_SIZE: layout::StructSize = layout::StructSize {
+            data: 2,
+            pointers: 9,
+        };
+        pub const TYPE_ID: u64 = 0xe106_8a6a_ee02_baba;
+    }
 }
 
 pub mod pair {
-  #[derive(Copy, Clone)]
-  pub struct Owned;
-  impl <'a> ::capnp::traits::Owned<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
-  impl <'a> ::capnp::traits::OwnedStruct<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
-  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
-
-  #[derive(Clone, Copy)]
-  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-
-  impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-    #[inline]
-    fn type_id() -> u64 { _private::TYPE_ID }
-  }
-  impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-    fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
-      Reader { reader: reader,  }
-    }
-  }
-
-  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::std::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-      ::std::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
-    }
-  }
-
-  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-      self.reader
-    }
-  }
-
-  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-    }
-  }
-
-  impl <'a,> Reader<'a,>  {
-    pub fn reborrow(&self) -> Reader<> {
-      Reader { .. *self }
-    }
-
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.reader.total_size()
-    }
-    #[inline]
-    pub fn get_key(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
-      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::std::option::Option::None)
-    }
-    pub fn has_key(&self) -> bool {
-      !self.reader.get_pointer_field(0).is_null()
-    }
-    #[inline]
-    pub fn get_value(self) -> crate::record_capnp::pair::value::Reader<'a> {
-      ::capnp::traits::FromStructReader::new(self.reader)
-    }
-  }
-
-  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-  impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-    #[inline]
-    fn struct_size() -> ::capnp::private::layout::StructSize { _private::STRUCT_SIZE }
-  }
-  impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-    #[inline]
-    fn type_id() -> u64 { _private::TYPE_ID }
-  }
-  impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-    fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
-      Builder { builder: builder,  }
-    }
-  }
-
-  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-    }
-  }
-
-  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-      ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
-    }
-    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::std::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-      ::std::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(_private::STRUCT_SIZE, default)?))
-    }
-  }
-
-  impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
-    fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-  }
-
-  impl <'a,> Builder<'a,>  {
-    pub fn into_reader(self) -> Reader<'a,> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
-    }
-    pub fn reborrow(&mut self) -> Builder<> {
-      Builder { .. *self }
-    }
-    pub fn reborrow_as_reader(&self) -> Reader<> {
-      ::capnp::traits::FromStructReader::new(self.builder.into_reader())
-    }
-
-    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-      self.builder.into_reader().total_size()
-    }
-    #[inline]
-    pub fn get_key(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
-      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::std::option::Option::None)
-    }
-    #[inline]
-    pub fn set_key(&mut self, value: ::capnp::text::Reader)  {
-      self.builder.get_pointer_field(0).set_text(value);
-    }
-    #[inline]
-    pub fn init_key(self, size: u32) -> ::capnp::text::Builder<'a> {
-      self.builder.get_pointer_field(0).init_text(size)
-    }
-    pub fn has_key(&self) -> bool {
-      !self.builder.get_pointer_field(0).is_null()
-    }
-    #[inline]
-    pub fn get_value(self) -> crate::record_capnp::pair::value::Builder<'a> {
-      ::capnp::traits::FromStructBuilder::new(self.builder)
-    }
-    #[inline]
-    pub fn init_value(self, ) -> crate::record_capnp::pair::value::Builder<'a> {
-      self.builder.set_data_field::<u16>(0, 0);
-      self.builder.get_pointer_field(1).clear();
-      self.builder.set_bool_field(16, false);
-      self.builder.set_data_field::<f64>(1, 0f64);
-      self.builder.set_data_field::<i64>(1, 0i64);
-      self.builder.set_data_field::<u64>(1, 0u64);
-      ::capnp::traits::FromStructBuilder::new(self.builder)
-    }
-  }
-
-  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
-  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
-      Pipeline { _typeless: typeless,  }
-    }
-  }
-  impl Pipeline  {
-    pub fn get_value(&self) -> crate::record_capnp::pair::value::Pipeline {
-      ::capnp::capability::FromTypelessPipeline::new(self._typeless.noop())
-    }
-  }
-  mod _private {
-    use capnp::private::layout;
-    pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 2, pointers: 2 };
-    pub const TYPE_ID: u64 = 0xb4a6_8d38_a716_233d;
-  }
-
-  pub mod value {
-    pub use self::Which::{String,Bool,F64,I64,U64,Null};
-
     #[derive(Copy, Clone)]
     pub struct Owned;
-    impl <'a> ::capnp::traits::Owned<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
-    impl <'a> ::capnp::traits::OwnedStruct<'a> for Owned { type Reader = Reader<'a>; type Builder = Builder<'a>; }
-    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+    impl<'a> ::capnp::traits::Owned<'a> for Owned {
+        type Reader = Reader<'a>;
+        type Builder = Builder<'a>;
+    }
+    impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
+        type Reader = Reader<'a>;
+        type Builder = Builder<'a>;
+    }
+    impl ::capnp::traits::Pipelined for Owned {
+        type Pipeline = Pipeline;
+    }
 
     #[derive(Clone, Copy)]
-    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
-
-    impl <'a,> ::capnp::traits::HasTypeId for Reader<'a,>  {
-      #[inline]
-      fn type_id() -> u64 { _private::TYPE_ID }
-    }
-    impl <'a,> ::capnp::traits::FromStructReader<'a> for Reader<'a,>  {
-      fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a,> {
-        Reader { reader: reader,  }
-      }
+    pub struct Reader<'a> {
+        reader: ::capnp::private::layout::StructReader<'a>,
     }
 
-    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
-      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::std::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Reader<'a,>> {
-        ::std::result::Result::Ok(::capnp::traits::FromStructReader::new(reader.get_struct(default)?))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
-      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
-        self.reader
-      }
-    }
-
-    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
-      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
-        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> Reader<'a,>  {
-      pub fn reborrow(&self) -> Reader<> {
-        Reader { .. *self }
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.reader.total_size()
-      }
-      pub fn has_string(&self) -> bool {
-        if self.reader.get_data_field::<u16>(0) != 0 { return false; }
-        !self.reader.get_pointer_field(1).is_null()
-      }
-      #[inline]
-      pub fn which(self) -> ::std::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
-        match self.reader.get_data_field::<u16>(0) {
-          0 => {
-            ::std::result::Result::Ok(String(
-              ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::std::option::Option::None)
-            ))
-          }
-          1 => {
-            ::std::result::Result::Ok(Bool(
-              self.reader.get_bool_field(16)
-            ))
-          }
-          2 => {
-            ::std::result::Result::Ok(F64(
-              self.reader.get_data_field::<f64>(1)
-            ))
-          }
-          3 => {
-            ::std::result::Result::Ok(I64(
-              self.reader.get_data_field::<i64>(1)
-            ))
-          }
-          4 => {
-            ::std::result::Result::Ok(U64(
-              self.reader.get_data_field::<u64>(1)
-            ))
-          }
-          5 => {
-            ::std::result::Result::Ok(Null(
-              ()
-            ))
-          }
-          x => ::std::result::Result::Err(::capnp::NotInSchema(x))
+    impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+        #[inline]
+        fn type_id() -> u64 {
+            _private::TYPE_ID
         }
-      }
     }
-
-    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
-    impl <'a,> ::capnp::traits::HasStructSize for Builder<'a,>  {
-      #[inline]
-      fn struct_size() -> ::capnp::private::layout::StructSize { _private::STRUCT_SIZE }
-    }
-    impl <'a,> ::capnp::traits::HasTypeId for Builder<'a,>  {
-      #[inline]
-      fn type_id() -> u64 { _private::TYPE_ID }
-    }
-    impl <'a,> ::capnp::traits::FromStructBuilder<'a> for Builder<'a,>  {
-      fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a, > {
-        Builder { builder: builder,  }
-      }
-    }
-
-    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
-      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
-        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
-      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Builder<'a,> {
-        ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
-      }
-      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::std::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Builder<'a,>> {
-        ::std::result::Result::Ok(::capnp::traits::FromStructBuilder::new(builder.get_struct(_private::STRUCT_SIZE, default)?))
-      }
-    }
-
-    impl <'a,> ::capnp::traits::SetPointerBuilder<Builder<'a,>> for Reader<'a,>  {
-      fn set_pointer_builder<'b>(pointer: ::capnp::private::layout::PointerBuilder<'b>, value: Reader<'a,>, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
-    }
-
-    impl <'a,> Builder<'a,>  {
-      pub fn into_reader(self) -> Reader<'a,> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
-      }
-      pub fn reborrow(&mut self) -> Builder<> {
-        Builder { .. *self }
-      }
-      pub fn reborrow_as_reader(&self) -> Reader<> {
-        ::capnp::traits::FromStructReader::new(self.builder.into_reader())
-      }
-
-      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
-        self.builder.into_reader().total_size()
-      }
-      #[inline]
-      pub fn set_string(&mut self, value: ::capnp::text::Reader)  {
-        self.builder.set_data_field::<u16>(0, 0);
-        self.builder.get_pointer_field(1).set_text(value);
-      }
-      #[inline]
-      pub fn init_string(self, size: u32) -> ::capnp::text::Builder<'a> {
-        self.builder.set_data_field::<u16>(0, 0);
-        self.builder.get_pointer_field(1).init_text(size)
-      }
-      pub fn has_string(&self) -> bool {
-        if self.builder.get_data_field::<u16>(0) != 0 { return false; }
-        !self.builder.get_pointer_field(1).is_null()
-      }
-      #[inline]
-      pub fn set_bool(&mut self, value: bool)  {
-        self.builder.set_data_field::<u16>(0, 1);
-        self.builder.set_bool_field(16, value);
-      }
-      #[inline]
-      pub fn set_f64(&mut self, value: f64)  {
-        self.builder.set_data_field::<u16>(0, 2);
-        self.builder.set_data_field::<f64>(1, value);
-      }
-      #[inline]
-      pub fn set_i64(&mut self, value: i64)  {
-        self.builder.set_data_field::<u16>(0, 3);
-        self.builder.set_data_field::<i64>(1, value);
-      }
-      #[inline]
-      pub fn set_u64(&mut self, value: u64)  {
-        self.builder.set_data_field::<u16>(0, 4);
-        self.builder.set_data_field::<u64>(1, value);
-      }
-      #[inline]
-      pub fn set_null(&mut self, _value: ())  {
-        self.builder.set_data_field::<u16>(0, 5);
-      }
-      #[inline]
-      pub fn which(self) -> ::std::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
-        match self.builder.get_data_field::<u16>(0) {
-          0 => {
-            ::std::result::Result::Ok(String(
-              ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::std::option::Option::None)
-            ))
-          }
-          1 => {
-            ::std::result::Result::Ok(Bool(
-              self.builder.get_bool_field(16)
-            ))
-          }
-          2 => {
-            ::std::result::Result::Ok(F64(
-              self.builder.get_data_field::<f64>(1)
-            ))
-          }
-          3 => {
-            ::std::result::Result::Ok(I64(
-              self.builder.get_data_field::<i64>(1)
-            ))
-          }
-          4 => {
-            ::std::result::Result::Ok(U64(
-              self.builder.get_data_field::<u64>(1)
-            ))
-          }
-          5 => {
-            ::std::result::Result::Ok(Null(
-              ()
-            ))
-          }
-          x => ::std::result::Result::Err(::capnp::NotInSchema(x))
+    impl<'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
+        fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
+            Reader { reader: reader }
         }
-      }
     }
 
-    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+    impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+        fn get_from_pointer(
+            reader: &::capnp::private::layout::PointerReader<'a>,
+            default: ::std::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Reader<'a>> {
+            ::std::result::Result::Ok(::capnp::traits::FromStructReader::new(
+                reader.get_struct(default)?,
+            ))
+        }
+    }
+
+    impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+        fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+            self.reader
+        }
+    }
+
+    impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+        fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+            self.reader
+                .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+        }
+    }
+
+    impl<'a> Reader<'a> {
+        pub fn reborrow(&self) -> Reader {
+            Reader { ..*self }
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.reader.total_size()
+        }
+        #[inline]
+        pub fn get_key(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
+            ::capnp::traits::FromPointerReader::get_from_pointer(
+                &self.reader.get_pointer_field(0),
+                ::std::option::Option::None,
+            )
+        }
+        pub fn has_key(&self) -> bool {
+            !self.reader.get_pointer_field(0).is_null()
+        }
+        #[inline]
+        pub fn get_value(self) -> crate::record_capnp::pair::value::Reader<'a> {
+            ::capnp::traits::FromStructReader::new(self.reader)
+        }
+    }
+
+    pub struct Builder<'a> {
+        builder: ::capnp::private::layout::StructBuilder<'a>,
+    }
+    impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+        #[inline]
+        fn struct_size() -> ::capnp::private::layout::StructSize {
+            _private::STRUCT_SIZE
+        }
+    }
+    impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+        #[inline]
+        fn type_id() -> u64 {
+            _private::TYPE_ID
+        }
+    }
+    impl<'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
+        fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
+            Builder { builder: builder }
+        }
+    }
+
+    impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+        fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+            self.builder
+                .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+        }
+    }
+
+    impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+        fn init_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            _size: u32,
+        ) -> Builder<'a> {
+            ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+        }
+        fn get_from_pointer(
+            builder: ::capnp::private::layout::PointerBuilder<'a>,
+            default: ::std::option::Option<&'a [::capnp::Word]>,
+        ) -> ::capnp::Result<Builder<'a>> {
+            ::std::result::Result::Ok(::capnp::traits::FromStructBuilder::new(
+                builder.get_struct(_private::STRUCT_SIZE, default)?,
+            ))
+        }
+    }
+
+    impl<'a> ::capnp::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+        fn set_pointer_builder<'b>(
+            pointer: ::capnp::private::layout::PointerBuilder<'b>,
+            value: Reader<'a>,
+            canonicalize: bool,
+        ) -> ::capnp::Result<()> {
+            pointer.set_struct(&value.reader, canonicalize)
+        }
+    }
+
+    impl<'a> Builder<'a> {
+        pub fn into_reader(self) -> Reader<'a> {
+            ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        }
+        pub fn reborrow(&mut self) -> Builder {
+            Builder { ..*self }
+        }
+        pub fn reborrow_as_reader(&self) -> Reader {
+            ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+        }
+
+        pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+            self.builder.into_reader().total_size()
+        }
+        #[inline]
+        pub fn get_key(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
+            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                self.builder.get_pointer_field(0),
+                ::std::option::Option::None,
+            )
+        }
+        #[inline]
+        pub fn set_key(&mut self, value: ::capnp::text::Reader) {
+            self.builder.get_pointer_field(0).set_text(value);
+        }
+        #[inline]
+        pub fn init_key(self, size: u32) -> ::capnp::text::Builder<'a> {
+            self.builder.get_pointer_field(0).init_text(size)
+        }
+        pub fn has_key(&self) -> bool {
+            !self.builder.get_pointer_field(0).is_null()
+        }
+        #[inline]
+        pub fn get_value(self) -> crate::record_capnp::pair::value::Builder<'a> {
+            ::capnp::traits::FromStructBuilder::new(self.builder)
+        }
+        #[inline]
+        pub fn init_value(self) -> crate::record_capnp::pair::value::Builder<'a> {
+            self.builder.set_data_field::<u16>(0, 0);
+            self.builder.get_pointer_field(1).clear();
+            self.builder.set_bool_field(16, false);
+            self.builder.set_data_field::<f64>(1, 0f64);
+            self.builder.set_data_field::<i64>(1, 0i64);
+            self.builder.set_data_field::<u64>(1, 0u64);
+            ::capnp::traits::FromStructBuilder::new(self.builder)
+        }
+    }
+
+    pub struct Pipeline {
+        _typeless: ::capnp::any_pointer::Pipeline,
+    }
     impl ::capnp::capability::FromTypelessPipeline for Pipeline {
-      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
-        Pipeline { _typeless: typeless,  }
-      }
+        fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+            Pipeline {
+                _typeless: typeless,
+            }
+        }
     }
-    impl Pipeline  {
+    impl Pipeline {
+        pub fn get_value(&self) -> crate::record_capnp::pair::value::Pipeline {
+            ::capnp::capability::FromTypelessPipeline::new(self._typeless.noop())
+        }
     }
     mod _private {
-      use capnp::private::layout;
-      pub const STRUCT_SIZE: layout::StructSize = layout::StructSize { data: 2, pointers: 2 };
-      pub const TYPE_ID: u64 = 0x8a99_4a2a_ad4d_9204;
+        use capnp::private::layout;
+        pub const STRUCT_SIZE: layout::StructSize = layout::StructSize {
+            data: 2,
+            pointers: 2,
+        };
+        pub const TYPE_ID: u64 = 0xb4a6_8d38_a716_233d;
     }
-    pub enum Which<A0> {
-      String(A0),
-      Bool(bool),
-      F64(f64),
-      I64(i64),
-      U64(u64),
-      Null(()),
+
+    pub mod value {
+        pub use self::Which::{Bool, Null, String, F64, I64, U64};
+
+        #[derive(Copy, Clone)]
+        pub struct Owned;
+        impl<'a> ::capnp::traits::Owned<'a> for Owned {
+            type Reader = Reader<'a>;
+            type Builder = Builder<'a>;
+        }
+        impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
+            type Reader = Reader<'a>;
+            type Builder = Builder<'a>;
+        }
+        impl ::capnp::traits::Pipelined for Owned {
+            type Pipeline = Pipeline;
+        }
+
+        #[derive(Clone, Copy)]
+        pub struct Reader<'a> {
+            reader: ::capnp::private::layout::StructReader<'a>,
+        }
+
+        impl<'a> ::capnp::traits::HasTypeId for Reader<'a> {
+            #[inline]
+            fn type_id() -> u64 {
+                _private::TYPE_ID
+            }
+        }
+        impl<'a> ::capnp::traits::FromStructReader<'a> for Reader<'a> {
+            fn new(reader: ::capnp::private::layout::StructReader<'a>) -> Reader<'a> {
+                Reader { reader: reader }
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerReader<'a> for Reader<'a> {
+            fn get_from_pointer(
+                reader: &::capnp::private::layout::PointerReader<'a>,
+                default: ::std::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Reader<'a>> {
+                ::std::result::Result::Ok(::capnp::traits::FromStructReader::new(
+                    reader.get_struct(default)?,
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a> {
+            fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+                self.reader
+            }
+        }
+
+        impl<'a> ::capnp::traits::Imbue<'a> for Reader<'a> {
+            fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+                self.reader
+                    .imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+            }
+        }
+
+        impl<'a> Reader<'a> {
+            pub fn reborrow(&self) -> Reader {
+                Reader { ..*self }
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.reader.total_size()
+            }
+            pub fn has_string(&self) -> bool {
+                if self.reader.get_data_field::<u16>(0) != 0 {
+                    return false;
+                }
+                !self.reader.get_pointer_field(1).is_null()
+            }
+            #[inline]
+            pub fn which(self) -> ::std::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
+                match self.reader.get_data_field::<u16>(0) {
+                    0 => ::std::result::Result::Ok(String(
+                        ::capnp::traits::FromPointerReader::get_from_pointer(
+                            &self.reader.get_pointer_field(1),
+                            ::std::option::Option::None,
+                        ),
+                    )),
+                    1 => ::std::result::Result::Ok(Bool(self.reader.get_bool_field(16))),
+                    2 => ::std::result::Result::Ok(F64(self.reader.get_data_field::<f64>(1))),
+                    3 => ::std::result::Result::Ok(I64(self.reader.get_data_field::<i64>(1))),
+                    4 => ::std::result::Result::Ok(U64(self.reader.get_data_field::<u64>(1))),
+                    5 => ::std::result::Result::Ok(Null(())),
+                    x => ::std::result::Result::Err(::capnp::NotInSchema(x)),
+                }
+            }
+        }
+
+        pub struct Builder<'a> {
+            builder: ::capnp::private::layout::StructBuilder<'a>,
+        }
+        impl<'a> ::capnp::traits::HasStructSize for Builder<'a> {
+            #[inline]
+            fn struct_size() -> ::capnp::private::layout::StructSize {
+                _private::STRUCT_SIZE
+            }
+        }
+        impl<'a> ::capnp::traits::HasTypeId for Builder<'a> {
+            #[inline]
+            fn type_id() -> u64 {
+                _private::TYPE_ID
+            }
+        }
+        impl<'a> ::capnp::traits::FromStructBuilder<'a> for Builder<'a> {
+            fn new(builder: ::capnp::private::layout::StructBuilder<'a>) -> Builder<'a> {
+                Builder { builder: builder }
+            }
+        }
+
+        impl<'a> ::capnp::traits::ImbueMut<'a> for Builder<'a> {
+            fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+                self.builder
+                    .imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+            }
+        }
+
+        impl<'a> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a> {
+            fn init_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                _size: u32,
+            ) -> Builder<'a> {
+                ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
+            }
+            fn get_from_pointer(
+                builder: ::capnp::private::layout::PointerBuilder<'a>,
+                default: ::std::option::Option<&'a [::capnp::Word]>,
+            ) -> ::capnp::Result<Builder<'a>> {
+                ::std::result::Result::Ok(::capnp::traits::FromStructBuilder::new(
+                    builder.get_struct(_private::STRUCT_SIZE, default)?,
+                ))
+            }
+        }
+
+        impl<'a> ::capnp::traits::SetPointerBuilder<Builder<'a>> for Reader<'a> {
+            fn set_pointer_builder<'b>(
+                pointer: ::capnp::private::layout::PointerBuilder<'b>,
+                value: Reader<'a>,
+                canonicalize: bool,
+            ) -> ::capnp::Result<()> {
+                pointer.set_struct(&value.reader, canonicalize)
+            }
+        }
+
+        impl<'a> Builder<'a> {
+            pub fn into_reader(self) -> Reader<'a> {
+                ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+            }
+            pub fn reborrow(&mut self) -> Builder {
+                Builder { ..*self }
+            }
+            pub fn reborrow_as_reader(&self) -> Reader {
+                ::capnp::traits::FromStructReader::new(self.builder.into_reader())
+            }
+
+            pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+                self.builder.into_reader().total_size()
+            }
+            #[inline]
+            pub fn set_string(&mut self, value: ::capnp::text::Reader) {
+                self.builder.set_data_field::<u16>(0, 0);
+                self.builder.get_pointer_field(1).set_text(value);
+            }
+            #[inline]
+            pub fn init_string(self, size: u32) -> ::capnp::text::Builder<'a> {
+                self.builder.set_data_field::<u16>(0, 0);
+                self.builder.get_pointer_field(1).init_text(size)
+            }
+            pub fn has_string(&self) -> bool {
+                if self.builder.get_data_field::<u16>(0) != 0 {
+                    return false;
+                }
+                !self.builder.get_pointer_field(1).is_null()
+            }
+            #[inline]
+            pub fn set_bool(&mut self, value: bool) {
+                self.builder.set_data_field::<u16>(0, 1);
+                self.builder.set_bool_field(16, value);
+            }
+            #[inline]
+            pub fn set_f64(&mut self, value: f64) {
+                self.builder.set_data_field::<u16>(0, 2);
+                self.builder.set_data_field::<f64>(1, value);
+            }
+            #[inline]
+            pub fn set_i64(&mut self, value: i64) {
+                self.builder.set_data_field::<u16>(0, 3);
+                self.builder.set_data_field::<i64>(1, value);
+            }
+            #[inline]
+            pub fn set_u64(&mut self, value: u64) {
+                self.builder.set_data_field::<u16>(0, 4);
+                self.builder.set_data_field::<u64>(1, value);
+            }
+            #[inline]
+            pub fn set_null(&mut self, _value: ()) {
+                self.builder.set_data_field::<u16>(0, 5);
+            }
+            #[inline]
+            pub fn which(self) -> ::std::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
+                match self.builder.get_data_field::<u16>(0) {
+                    0 => ::std::result::Result::Ok(String(
+                        ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                            self.builder.get_pointer_field(1),
+                            ::std::option::Option::None,
+                        ),
+                    )),
+                    1 => ::std::result::Result::Ok(Bool(self.builder.get_bool_field(16))),
+                    2 => ::std::result::Result::Ok(F64(self.builder.get_data_field::<f64>(1))),
+                    3 => ::std::result::Result::Ok(I64(self.builder.get_data_field::<i64>(1))),
+                    4 => ::std::result::Result::Ok(U64(self.builder.get_data_field::<u64>(1))),
+                    5 => ::std::result::Result::Ok(Null(())),
+                    x => ::std::result::Result::Err(::capnp::NotInSchema(x)),
+                }
+            }
+        }
+
+        pub struct Pipeline {
+            _typeless: ::capnp::any_pointer::Pipeline,
+        }
+        impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+            fn new(typeless: ::capnp::any_pointer::Pipeline) -> Pipeline {
+                Pipeline {
+                    _typeless: typeless,
+                }
+            }
+        }
+        impl Pipeline {}
+        mod _private {
+            use capnp::private::layout;
+            pub const STRUCT_SIZE: layout::StructSize = layout::StructSize {
+                data: 2,
+                pointers: 2,
+            };
+            pub const TYPE_ID: u64 = 0x8a99_4a2a_ad4d_9204;
+        }
+        pub enum Which<A0> {
+            String(A0),
+            Bool(bool),
+            F64(f64),
+            I64(i64),
+            U64(u64),
+            Null(()),
+        }
+        pub type WhichReader<'a> = Which<::capnp::Result<::capnp::text::Reader<'a>>>;
+        pub type WhichBuilder<'a> = Which<::capnp::Result<::capnp::text::Builder<'a>>>;
     }
-    pub type WhichReader<'a,> = Which<::capnp::Result<::capnp::text::Reader<'a>>>;
-    pub type WhichBuilder<'a,> = Which<::capnp::Result<::capnp::text::Builder<'a>>>;
-  }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Running ```cargo fmt``` and updating minor version

Fixed two unit tests failing that had wrong timestamp from 2021
```
flowgger::encoder::ltsv_encoder::test_ltsv_full_encode_multiple_sd
flowgger::encoder::ltsv_encoder::test_ltsv_full_encode_no_sd
```

Tested locally as well running some manual logs against it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
