### PR TITLE
validate time format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the time project will be documented in this file.
 ---
 
 
+<a name="0.3.1"></a>
+### 0.3.1 (2022-04-26)
+
+#### Changes
+
+*   Added warning if running with old time format from chrono and falling back to default one
 
 <a name="0.3.0"></a>
 ### 0.3.0 (2022-03-14)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "flowgger"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Frank Denis <github@pureftpd.org>", "Matteo Bigoi <bigo@crisidev.org>", "Vivien Chene <viv.chene@gmail.com>", "Francesco Berni <kurojishi@kurojishi.me>"]
 build = "build.rs"
 repository = "https://github.com/awslabs/flowgger"

--- a/src/flowgger/output/file_output.rs
+++ b/src/flowgger/output/file_output.rs
@@ -2,6 +2,7 @@ use super::Output;
 use crate::flowgger::config::Config;
 use crate::flowgger::merger::Merger;
 use crate::flowgger::utils::rotating_file::RotatingFile;
+use crate::flowgger::validate_time_format_input;
 use std::io::{BufWriter, Write};
 use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
@@ -9,7 +10,7 @@ use std::thread;
 
 use std::io::stderr;
 const FILE_DEFAULT_BUFFER_SIZE: usize = 0;
-const FILE_DEFAULT_TIME_FORMAT: &str = "%Y%m%dT%H%M%SZ";
+const FILE_DEFAULT_TIME_FORMAT: &str = "[year][month][day]T[hour][minute][second]Z";
 const FILE_DEFAULT_ROTATION_SIZE: usize = 0;
 const FILE_DEFAULT_ROTATION_TIME: u32 = 0;
 const FILE_DEFAULT_ROTATION_MAXFILES: i32 = 50;
@@ -97,6 +98,12 @@ impl FileOutput {
                     .expect("output.file_rotation_timeformat should be a string")
                     .to_string()
             },
+        );
+
+        let time_format = validate_time_format_input(
+            "file_rotation_timeformat",
+            &time_format,
+            FILE_DEFAULT_TIME_FORMAT.to_string(),
         );
 
         FileOutput {

--- a/src/flowgger/utils/rotating_file.rs
+++ b/src/flowgger/utils/rotating_file.rs
@@ -32,7 +32,7 @@ impl RotatingFile {
     ///
     /// If the time trigger is specified (max_time >0):
     /// All file names are appended with their creation timestamp. i.e. configured file "abcd.log" might become
-    /// "abcd-20180108T0143Z.log" if the time format is configured to be "%Y%m%dT%H%MZ"
+    /// "abcd-20180108T0143Z.log" if the time format is configured to be "[year][month][day]T[hour][minute]Z"
     /// A file "expires" when its creation time + configured max_time is reached (based on current UTC time).
     /// Rotation occurs when a write is requested to an expired file. The file is then closed and a new one is created.
     /// # Notes:
@@ -83,7 +83,7 @@ impl RotatingFile {
     ///     - basename = 'logs/syslog.log'
     ///     - max_time = 2
     ///     - app started on 2018-01-08 at 01:43 UTC
-    ///     - time format is "%Y%m%dT%H%M%SZ"
+    ///     - time format is "[year][month][day]T[hour][minute][second]Z"
     ///
     /// The following files will be generated:
     ///     - Current file = 'logs/syslog-20180108T014343Z.log'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added warning if running with old time format from chrono and falling back to default one if invalid.

The check is simple - just making sure that if `%` symbol is used in time format strings, it needs to be preceded by two `\` - this two `\` are necessary to have a valid toml file. 

So this is valid value: "\\%Y"
And this is not: "%Y"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
