### PR TITLE
Update fuzzing test to store output in a temporary directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ optional = true
 
 [dependencies]
 capnp = { version = "0.14", optional = true }
-clap = "3"
+clap = "4"
 flate2 = "1"
 glob = { version = "0.3", optional = true }
 kafka = { version = "0.8", features = ["snappy", "gzip", "security"], optional = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,8 @@ fn main() {
         )
         .get_matches();
     let config_file = matches
-        .value_of("config_file")
+        .get_one::<String>("config_file")
+        .map(|s| s.as_ref())
         .unwrap_or(DEFAULT_CONFIG_FILE);
     let _ = writeln!(stderr(), "Flowgger {}", FLOWGGER_VERSION_STRING);
     flowgger::start(config_file)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Stores fuzzing test output in a temporary directory, fixing issues with accessing underlying host filesystems where tests are being run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
