### PR TITLE
Update fuzzing test to store output in a temporary directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "flowgger"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Frank Denis <github@pureftpd.org>", "Matteo Bigoi <bigo@crisidev.org>", "Vivien Chene <viv.chene@gmail.com>", "Francesco Berni <kurojishi@kurojishi.me>"]
 build = "build.rs"
 repository = "https://github.com/awslabs/flowgger"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now stores fuzzing test output in a temp dir, fixing issues with accessing the underlying filesystem on the test host

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
